### PR TITLE
Fix submodelrepository mongodb backend

### DIFF
--- a/basyx.submodelrepository/basyx.submodelrepository-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/InMemorySubmodelRepositoryFactory.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/InMemorySubmodelRepositoryFactory.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
  * 
  * @author schnicke
  */
-@ConditionalOnExpression("'${basyx.aasrepository.backend}'.equals('InMemory') or '${basyx.backend}'.equals('InMemory')")
+@ConditionalOnExpression("'${basyx.submodelrepository.backend}'.equals('InMemory') or '${basyx.backend}'.equals('InMemory')")
 @Component
 public class InMemorySubmodelRepositoryFactory implements SubmodelRepositoryFactory {
 	private SubmodelServiceFactory submodelServiceFactory;

--- a/basyx.submodelrepository/basyx.submodelrepository-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/InMemorySubmodelRepositoryFactory.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/InMemorySubmodelRepositoryFactory.java
@@ -26,6 +26,7 @@ package org.eclipse.digitaltwin.basyx.submodelrepository;
 
 import org.eclipse.digitaltwin.basyx.submodelservice.SubmodelServiceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Component;
  * 
  * @author schnicke
  */
+@ConditionalOnExpression("'${basyx.aasrepository.backend}'.equals('InMemory') or '${basyx.backend}'.equals('InMemory')")
 @Component
 public class InMemorySubmodelRepositoryFactory implements SubmodelRepositoryFactory {
 	private SubmodelServiceFactory submodelServiceFactory;

--- a/basyx.submodelrepository/basyx.submodelrepository-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/MongoDBSubmodelRepositoryFactory.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/MongoDBSubmodelRepositoryFactory.java
@@ -30,7 +30,9 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 import org.eclipse.digitaltwin.basyx.submodelservice.SubmodelServiceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Component;
 
 /**
  * SubmodelRepository factory returning a MongoDb backend SubmodelRepository
@@ -38,6 +40,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
  * @author jungjan
  *
  */
+@Component
+@ConditionalOnExpression("'${basyx.backend}'.equals('MongoDB')")
 public class MongoDBSubmodelRepositoryFactory implements SubmodelRepositoryFactory {
 
 	private MongoTemplate mongoTemplate;
@@ -45,14 +49,15 @@ public class MongoDBSubmodelRepositoryFactory implements SubmodelRepositoryFacto
 	private SubmodelServiceFactory submodelServiceFactory;
 	private Collection<Submodel> submodels;
 
-	@Autowired
+	@Autowired(required = false)
 	public MongoDBSubmodelRepositoryFactory(MongoTemplate mongoTemplate, @Value("${basyx.submodelrepository.mongodb.collectionName:submodel-repo}") String collectionName, SubmodelServiceFactory submodelServiceFactory) {
 		this.mongoTemplate = mongoTemplate;
 		this.collectionName = collectionName;
 		this.submodelServiceFactory = submodelServiceFactory;
 	}
 
-	@Autowired
+
+	@Autowired(required = false)
 	public MongoDBSubmodelRepositoryFactory(MongoTemplate mongoTemplate, @Value("${basyx.submodelrepository.mongodb.collectionName:submodel-repo}") String collectionName, SubmodelServiceFactory submodelServiceFactory,
 			Collection<Submodel> submodels) {
 		this(mongoTemplate, collectionName, submodelServiceFactory);

--- a/basyx.submodelrepository/basyx.submodelrepository-http/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/DummySubmodelRepositoryComponent.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-http/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/DummySubmodelRepositoryComponent.java
@@ -27,6 +27,7 @@
 package org.eclipse.digitaltwin.basyx.submodelrepository.http;
 
 import org.eclipse.digitaltwin.basyx.submodelrepository.InMemorySubmodelRepository;
+import org.eclipse.digitaltwin.basyx.submodelservice.InMemorySubmodelServiceFactory;
 import org.eclipse.digitaltwin.basyx.submodelservice.SubmodelServiceFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -35,7 +36,7 @@ import org.springframework.context.annotation.Bean;
 public class DummySubmodelRepositoryComponent {
 
 	@Bean
-	public InMemorySubmodelRepository createSubmodelRepository(SubmodelServiceFactory submodelServiceFactory) {
-		return new InMemorySubmodelRepository(submodelServiceFactory);
+	public InMemorySubmodelRepository createSubmodelRepository() {
+		return new InMemorySubmodelRepository(new InMemorySubmodelServiceFactory());
 	}
 }

--- a/basyx.submodelrepository/basyx.submodelrepository.component/pom.xml
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/pom.xml
@@ -29,6 +29,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.submodelrepository-backend-mongodb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.submodelrepository-feature-mqtt</artifactId>
 		</dependency>
 		<dependency>

--- a/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelServiceFactory.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelServiceFactory.java
@@ -27,6 +27,7 @@
 package org.eclipse.digitaltwin.basyx.submodelservice;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 /**
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Component;
  * @author schnicke
  *
  */
+@ConditionalOnExpression("'${basyx.submodelservice.backend}'.equals('InMemory') or '${basyx.backend}'.equals('InMemory')")
 @Component
 public class InMemorySubmodelServiceFactory implements SubmodelServiceFactory {
 


### PR DESCRIPTION
This pull request fixes the submodelrepository not using a mongoDB backend when basyx.backend=MongoDB in application.properties.