### PR TITLE
Add healthcheck in components dockerfile

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
+++ b/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
@@ -7,5 +7,5 @@ COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/shells || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
+++ b/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
@@ -6,4 +6,5 @@ COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/shells || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
+++ b/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
@@ -5,6 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
+ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/shells || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/shells || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
+++ b/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
@@ -7,5 +7,5 @@ COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/shells || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
+++ b/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
@@ -6,4 +6,5 @@ COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/shells || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
+++ b/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
@@ -5,6 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
+ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/shells || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/shells || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
+++ b/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
@@ -4,4 +4,8 @@ WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
+ARG PORT=8081
+ENV PORT=${PORT}
+EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasxfileserver/basyx.aasxfileserver.component/src/main/resources/application.properties
+++ b/basyx.aasxfileserver/basyx.aasxfileserver.component/src/main/resources/application.properties
@@ -16,7 +16,7 @@ basyx.backend = InMemory
 #spring.data.mongodb.uri=mongodb://mongoAdmin:mongoPassword@localhost:27017/?authMechanism=DEFAULT
 
 # Base Path for Spring Boot Actuator
-management.endpoints.web.base-path=/
+# management.endpoints.web.base-path=/
 
 ####################################################################################
 # Cross-Site Resource Sharing (CORS);

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
@@ -7,5 +7,5 @@ COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=30s CMD curl --fail http://localhost:${PORT}/concept-descriptions || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=30s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
@@ -5,6 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
+ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/concept-descriptions || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=30s CMD curl --fail http://localhost:${PORT}/concept-descriptions || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
@@ -6,4 +6,5 @@ COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/concept-descriptions || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
@@ -7,5 +7,5 @@ COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/submodels || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
@@ -5,6 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
+ENV PORT=${PORT}
 EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/submodels || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/submodels || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
@@ -6,4 +6,5 @@ COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:8081/submodels || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.submodelservice/basyx.submodelservice.component/src/main/resources/application.properties
+++ b/basyx.submodelservice/basyx.submodelservice.component/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=8081
 spring.application.name=Submodel Service
 
 # Base Path for Spring Boot Actuator
-management.endpoints.web.base-path=/
+# management.endpoints.web.base-path=/
 
 ####################################################################################
 # Cross-Site Resource Sharing (CORS);

--- a/examples/cd-repo.properties
+++ b/examples/cd-repo.properties
@@ -13,4 +13,4 @@ spring.data.mongodb.username=mongoAdmin
 spring.data.mongodb.password=mongoPassword
 
 # Base Path for Spring Boot Actuator
-management.endpoints.web.base-path=/
+# management.endpoints.web.base-path=/


### PR DESCRIPTION
With the integrated healthcheck, it is easier to determine container health.

![image](https://github.com/eclipse-basyx/basyx-java-server-sdk/assets/17963017/a941fa8d-a70d-48e6-8207-038124d8b492)

As further addition it would be nice to bump the jdk base image to eclipse temurin jdk 17.

What do you think? @FrankSchnicke 