### PR TITLE
Maven Docker Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vs
 /.vscode
 /.idea
+**.iml
 launchSettings.json
 .project
 *.pubxml

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
@@ -5,5 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
+ENV PORT=${PORT}
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
@@ -5,7 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
-ENV PORT=${PORT}
-EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
+ENV SERVER_PORT=${PORT}
+EXPOSE ${SERVER_PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${SERVER_PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/pom.xml
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/pom.xml
@@ -111,78 +111,63 @@
 				</configuration>
 			</plugin>
 		</plugins>
-		
-		<pluginManagement>
-			<plugins>
-				<!-- Build the docker image -->
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>0.43.0</version>
-					<configuration>
-						<images>
-							<image>
-								<name>${docker.username}/${docker.image.name}</name>
-								<build>
-									<tags>
-										<tag>${docker.image.tag}</tag>
-									</tags>
-									<contextDir>${project.basedir}</contextDir>
-								</build>
-								<run>
-									<ports>
-										<port>${docker.host.port}:${docker.container.port}</port>
-									</ports>
-									<wait>
-										<url>${docker.container.waitForEndpoint}</url>
-										<time>60000</time>
-									</wait>
-								</run>
-							</image>
-						</images>
-						<verbose>true</verbose>
-					</configuration>
-					<executions>
-						<execution>
-							<id>docker:build</id>
-							<phase>package</phase>
-							<goals>
-								<goal>build</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-up</id>
-							<phase>pre-integration-test</phase>
-							<goals>
-								<goal>start</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-down</id>
-							<phase>post-integration-test</phase>
-							<goals>
-								<goal>stop</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<profiles>
 		<profile>
 			<id>docker</id>
+      <activation>
+        <property>
+          <name>docker.namespace</name>
+        </property>
+      </activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <run>
+                    <ports>
+                      <port>${docker.host.port}:${docker.container.port}</port>
+                    </ports>
+                    <wait>
+                      <url>${docker.container.waitForEndpoint}</url>
+                      <time>60000</time>
+                    </wait>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+						<executions>
+							<execution>
+								<id>build-docker</id>
+							</execution>
+							<execution>
+								<id>push-docker</id>
+							</execution>
+							<execution>
+                <id>docker-compose-up</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-compose-down</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+						</executions>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-failsafe-plugin</artifactId>
-					</plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+          </plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/basyx.aasenvironment/basyx.aasenvironment.component/pom.xml
+++ b/basyx.aasenvironment/basyx.aasenvironment.component/pom.xml
@@ -114,74 +114,58 @@
 				</configuration>
 			</plugin>
 		</plugins>
-
-		<pluginManagement>
-			<plugins>
-				<!-- Build the docker image -->
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>0.43.0</version>
-					<configuration>
-						<images>
-							<image>
-								<name>${docker.namespace}/${docker.image.name}</name>
-								<build>
-									<tags>
-										<tag>${docker.image.tag}</tag>
-									</tags>
-									<contextDir>${project.basedir}</contextDir>
-								</build>
-								<run>
-									<ports>
-										<port>
-											${docker.host.port}:${docker.container.port}</port>
-									</ports>
-									<wait>
-										<url>${docker.container.waitForEndpoint}</url>
-										<time>60000</time>
-									</wait>
-								</run>
-							</image>
-						</images>
-						<verbose>true</verbose>
-					</configuration>
-					<executions>
-						<execution>
-							<id>docker:build</id>
-							<phase>package</phase>
-							<goals>
-								<goal>build</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-up</id>
-							<phase>pre-integration-test</phase>
-							<goals>
-								<goal>start</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-down</id>
-							<phase>post-integration-test</phase>
-							<goals>
-								<goal>stop</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<profiles>
 		<profile>
 			<id>docker</id>
+      <activation>
+        <property>
+          <name>docker.namespace</name>
+        </property>
+      </activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <run>
+                    <ports>
+                      <port>${docker.host.port}:${docker.container.port}</port>
+                    </ports>
+                    <wait>
+                      <url>${docker.container.waitForEndpoint}</url>
+                      <time>60000</time>
+                    </wait>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+						<executions>
+							<execution>
+								<id>build-docker</id>
+							</execution>
+							<execution>
+								<id>push-docker</id>
+							</execution>
+							<execution>
+                <id>docker-compose-up</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-compose-down</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+						</executions>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/basyx.aasregistry/pom.xml
+++ b/basyx.aasregistry/pom.xml
@@ -13,9 +13,8 @@
 	</parent>
 
 	<properties>
-		<docker.image.version>2.0.0-SNAPSHOT</docker.image.version>
 		<lombok.maven-plugin.version>1.18.20.0</lombok.maven-plugin.version>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -30,12 +29,7 @@
 		<maven-plugin.version>3.6.0</maven-plugin.version>
 		<maven-project.version>3.0-alpha-2</maven-project.version>
 		<mustache.compiler.version>0.9.4</mustache.compiler.version>
-		<snakeyaml.version>2.2</snakeyaml.version>
-		<docker.maven.plugin.version>0.43.4</docker.maven.plugin.version>
 		<docker.image.name>${project.artifactId}</docker.image.name>
-		<docker.pull.registry>docker.io</docker.pull.registry>
-		<docker.target.platforms>linux/amd64,linux/arm64</docker.target.platforms>
-		<docker.registry>docker.io</docker.registry>
 		<openapitools.version>6.6.0</openapitools.version>
 		<openapitools.jacksonnullable.version>0.2.6</openapitools.jacksonnullable.version>
 		<jsr305.version>3.0.2</jsr305.version>
@@ -100,11 +94,6 @@
 					<groupId>org.openapitools</groupId>
 					<artifactId>openapi-generator-maven-plugin</artifactId>
 					<version>${openapitools.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>${docker.maven.plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>de.dfki.cos.basys.common</groupId>
@@ -259,8 +248,7 @@
 		<profile>
 			<id>dockerbuild</id>
 			<activation>
-				<!-- This profile is always active if there is a Dockerfile and a user
-          name is given -->
+				<!-- This profile is always active if there is a Dockerfile and docker.namespace property is given -->
 				<file>
 					<exists>src/main/docker/Dockerfile</exists>
 				</file>
@@ -290,66 +278,25 @@
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <assembly>
+                      <descriptorRef>artifact</descriptorRef>
+                    </assembly>
+                    <dockerFile>Dockerfile</dockerFile>
+                    <contextDir>${project.basedir}/src/main/docker</contextDir>
+                  </build>
+                </image>
+              </images>
+            </configuration>
 						<executions>
 							<execution>
 								<id>build-docker</id>
-								<phase>package</phase>
-								<goals>
-									<goal>build</goal>
-								</goals>
-								<configuration>
-									<images>
-										<image>
-											<name>${docker.namespace}/${docker.image.name}</name>
-											<build>
-												<assembly>
-													<descriptorRef>artifact</descriptorRef>
-												</assembly>
-												<tags>
-													<tag>${docker.image.version}</tag>
-												</tags>
-												<dockerFile>Dockerfile</dockerFile>
-												<contextDir>${project.basedir}/src/main/docker</contextDir>
-												<!-- building non buildx image here to speed up build -->
-												<noCache>true</noCache>
-											</build>
-										</image>
-									</images>
-								</configuration>
 							</execution>
 							<execution>
 								<id>push-docker</id>
-								<phase>deploy</phase>
-								<goals>
-									<goal>build</goal>
-									<goal>push</goal>
-								</goals>
-								<configuration>
-									<images>
-										<image>
-											<name>${docker.namespace}/${docker.image.name}</name>
-											<!-- needs to be set to this registry https://github.com/fabric8io/docker-maven-plugin/pull/1578 -->
-											<registry>https://index.docker.io/v1/</registry>
-											<build>
-												<assembly>
-													<descriptorRef>artifact</descriptorRef>
-												</assembly>
-												<tags>
-													<tag>${docker.image.version}</tag>
-												</tags>
-												<dockerFile>Dockerfile</dockerFile>
-												<contextDir>${project.basedir}/src/main/docker</contextDir>
-												<buildx>
-													<platforms>${docker.target.platforms}</platforms>
-													<attestations>
-														<provenance>${docker.provenance}</provenance>
-													</attestations>
-												</buildx>
-												<noCache>true</noCache>
-											</build>
-										</image>
-									</images>
-								</configuration>
 							</execution>
 						</executions>
 					</plugin>

--- a/basyx.aasregistry/pom.xml
+++ b/basyx.aasregistry/pom.xml
@@ -14,7 +14,7 @@
 
 	<properties>
 		<lombok.maven-plugin.version>1.18.20.0</lombok.maven-plugin.version>
-		<java.version>17</java.version>
+		<java.version>11</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/basyx.aasrepository/basyx.aasrepository.component/pom.xml
+++ b/basyx.aasrepository/basyx.aasrepository.component/pom.xml
@@ -13,8 +13,7 @@
 
 	<properties>
 		<docker.image.name>aas-repository</docker.image.name>
-		<docker.container.waitForEndpoint>
-			http://localhost:${docker.host.port}/shells</docker.container.waitForEndpoint>
+		<docker.container.waitForEndpoint>http://localhost:${docker.host.port}/shells</docker.container.waitForEndpoint>
 	</properties>
 
 	<dependencies>
@@ -120,78 +119,61 @@
 				</configuration>
 			</plugin>
 		</plugins>
-
-		<pluginManagement>
-			<plugins>
-				<!-- Build the docker image -->
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>0.43.4</version>
-					<configuration>
-						<images>
-							<image>
-								<name>${docker.namespace}/${docker.image.name}</name>
-								<build>
-									<tags>
-										<tag>${docker.image.tag}</tag>
-									</tags>
-									<contextDir>${project.basedir}</contextDir>
-								</build>
-								<run>
-									<ports>
-										<port>
-											${docker.host.port}:${docker.container.port}</port>
-									</ports>
-									<wait>
-										<url>${docker.container.waitForEndpoint}</url>
-										<time>60000</time>
-									</wait>
-									<env>
-										<SPRING_PROFILES_ACTIVE>
-											integration</SPRING_PROFILES_ACTIVE>
-									</env>
-								</run>
-							</image>
-						</images>
-						<verbose>true</verbose>
-					</configuration>
-					<executions>
-						<execution>
-							<id>docker:build</id>
-							<phase>package</phase>
-							<goals>
-								<goal>build</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-up</id>
-							<phase>pre-integration-test</phase>
-							<goals>
-								<goal>start</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-down</id>
-							<phase>post-integration-test</phase>
-							<goals>
-								<goal>stop</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<profiles>
 		<profile>
 			<id>docker</id>
+      <activation>
+        <property>
+          <name>docker.namespace</name>
+        </property>
+      </activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <run>
+                    <ports>
+                      <port>${docker.host.port}:${docker.container.port}</port>
+                    </ports>
+                    <wait>
+                      <url>${docker.container.waitForEndpoint}</url>
+                      <time>60000</time>
+                    </wait>
+                    <env>
+                      <SPRING_PROFILES_ACTIVE>integration</SPRING_PROFILES_ACTIVE>
+                    </env>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+						<executions>
+							<execution>
+								<id>build-docker</id>
+							</execution>
+							<execution>
+								<id>push-docker</id>
+							</execution>
+							<execution>
+                <id>docker-compose-up</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-compose-down</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+						</executions>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
+++ b/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
@@ -5,7 +5,7 @@ ARG JAR_FILE=target/*-exec.jar
 COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
-ENV PORT=${PORT}
-EXPOSE ${PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
+ENV SERVER_PORT=${PORT}
+EXPOSE ${SERVER_PORT}
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${SERVER_PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
@@ -6,6 +6,6 @@ COPY ${JAR_FILE} basyxExecutable.jar
 COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 ENV SERVER_PORT=${PORT}
-EXPOSE ${PORT}
+EXPOSE ${SERVER_PORT}
 HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=30s CMD curl --fail http://localhost:${SERVER_PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/pom.xml
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/pom.xml
@@ -13,8 +13,7 @@
 
 	<properties>
 		<docker.image.name>conceptdescription-repository</docker.image.name>
-		<docker.container.waitForEndpoint>http://localhost:${docker.host.port}/concept-descriptions
-		</docker.container.waitForEndpoint>
+		<docker.container.waitForEndpoint>http://localhost:${docker.host.port}/concept-descriptions</docker.container.waitForEndpoint>
 	</properties>
 
 	<dependencies>
@@ -113,73 +112,58 @@
 				</configuration>
 			</plugin>
 		</plugins>
-
-		<pluginManagement>
-			<plugins>
-				<!-- Build the docker image -->
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>0.43.4</version>
-					<configuration>
-						<images>
-							<image>
-								<name>${docker.namespace}/${docker.image.name}</name>
-								<build>
-									<tags>
-										<tag>${docker.image.tag}</tag>
-									</tags>
-									<contextDir>${project.basedir}</contextDir>
-								</build>
-								<run>
-									<ports>
-										<port>${docker.host.port}:${docker.container.port}</port>
-									</ports>
-									<wait>
-										<url>${docker.container.waitForEndpoint}</url>
-										<time>60000</time>
-									</wait>
-								</run>
-							</image>
-						</images>
-						<verbose>true</verbose>
-					</configuration>
-					<executions>
-						<execution>
-							<id>docker:build</id>
-							<phase>package</phase>
-							<goals>
-								<goal>build</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-up</id>
-							<phase>pre-integration-test</phase>
-							<goals>
-								<goal>start</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-down</id>
-							<phase>post-integration-test</phase>
-							<goals>
-								<goal>stop</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<profiles>
 		<profile>
 			<id>docker</id>
+      <activation>
+        <property>
+          <name>docker.namespace</name>
+        </property>
+      </activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <run>
+                    <ports>
+                      <port>${docker.host.port}:${docker.container.port}</port>
+                    </ports>
+                    <wait>
+                      <url>${docker.container.waitForEndpoint}</url>
+                      <time>60000</time>
+                    </wait>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+						<executions>
+							<execution>
+								<id>build-docker</id>
+							</execution>
+							<execution>
+								<id>push-docker</id>
+							</execution>
+							<execution>
+                <id>docker-compose-up</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-compose-down</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+						</executions>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/basyx.submodelregistry/pom.xml
+++ b/basyx.submodelregistry/pom.xml
@@ -13,7 +13,6 @@
 	</parent>
 
 	<properties>
-		<docker.image.version>2.0.0-SNAPSHOT</docker.image.version>
 		<lombok.maven-plugin.version>1.18.20.0</lombok.maven-plugin.version>
 		<java.version>17</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
@@ -29,12 +28,7 @@
 		<maven-plugin.version>3.6.0</maven-plugin.version>
 		<maven-project.version>3.0-alpha-2</maven-project.version>
 		<mustache.compiler.version>0.9.4</mustache.compiler.version>
-		<snakeyaml.version>2.2</snakeyaml.version>
-		<docker.maven.plugin.version>0.43.4</docker.maven.plugin.version>
 		<docker.image.name>${project.artifactId}</docker.image.name>
-		<docker.pull.registry>docker.io</docker.pull.registry>
-		<docker.target.platforms>linux/amd64,linux/arm64</docker.target.platforms>
-		<docker.registry>docker.io</docker.registry>
 		<openapitools.version>6.6.0</openapitools.version>
 		<openapitools.jacksonnullable.version>0.2.6</openapitools.jacksonnullable.version>
 		<jsr305.version>3.0.2</jsr305.version>
@@ -87,11 +81,6 @@
 					<groupId>org.openapitools</groupId>
 					<artifactId>openapi-generator-maven-plugin</artifactId>
 					<version>${openapitools.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>${docker.maven.plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>de.dfki.cos.basys.common</groupId>
@@ -241,8 +230,7 @@
 		<profile>
 			<id>dockerbuild</id>
 			<activation>
-				<!-- This profile is always active if there is a Dockerfile and a user
-          name is given -->
+				<!-- This profile is always active if there is a Dockerfile and docker.namespace property is given -->
 				<file>
 					<exists>src/main/docker/Dockerfile</exists>
 				</file>
@@ -272,66 +260,25 @@
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <assembly>
+                      <descriptorRef>artifact</descriptorRef>
+                    </assembly>
+                    <dockerFile>Dockerfile</dockerFile>
+                    <contextDir>${project.basedir}/src/main/docker</contextDir>
+                  </build>
+                </image>
+              </images>
+            </configuration>
 						<executions>
 							<execution>
 								<id>build-docker</id>
-								<phase>package</phase>
-								<goals>
-									<goal>build</goal>
-								</goals>
-								<configuration>
-									<images>
-										<image>
-											<name>${docker.namespace}/${docker.image.name}</name>
-											<build>
-												<assembly>
-													<descriptorRef>artifact</descriptorRef>
-												</assembly>
-												<tags>
-													<tag>${docker.image.version}</tag>
-												</tags>
-												<dockerFile>Dockerfile</dockerFile>
-												<contextDir>${project.basedir}/src/main/docker</contextDir>
-												<!-- building non buildx image here to speed up build -->
-												<noCache>true</noCache>
-											</build>
-										</image>
-									</images>
-								</configuration>
 							</execution>
 							<execution>
 								<id>push-docker</id>
-								<phase>deploy</phase>
-								<goals>
-									<goal>build</goal>
-									<goal>push</goal>
-								</goals>
-								<configuration>
-									<images>
-										<image>
-											<name>${docker.namespace}/${docker.image.name}</name>
-											<!-- needs to be set to this registry https://github.com/fabric8io/docker-maven-plugin/pull/1578 -->
-											<registry>https://index.docker.io/v1/</registry>
-											<build>
-												<assembly>
-													<descriptorRef>artifact</descriptorRef>
-												</assembly>
-												<tags>
-													<tag>${docker.image.version}</tag>
-												</tags>
-												<dockerFile>Dockerfile</dockerFile>
-												<contextDir>${project.basedir}/src/main/docker</contextDir>
-												<buildx>
-													<platforms>${docker.target.platforms}</platforms>
-													<attestations>
-														<provenance>${docker.provenance}</provenance>
-													</attestations>
-												</buildx>
-												<noCache>true</noCache>
-											</build>
-										</image>
-									</images>
-								</configuration>
 							</execution>
 						</executions>
 					</plugin>

--- a/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
@@ -7,5 +7,5 @@ COPY src/main/resources/application.properties application.properties
 ARG PORT=8081
 ENV SERVER_PORT=${PORT}
 EXPOSE ${SERVER_PORT}
-HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${PORT}/actuator/health || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 --start-period=15s CMD curl --fail http://localhost:${SERVER_PORT}/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","basyxExecutable.jar"]

--- a/basyx.submodelrepository/basyx.submodelrepository.component/pom.xml
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/pom.xml
@@ -126,78 +126,61 @@
 				</configuration>
 			</plugin>
 		</plugins>
-
-		<pluginManagement>
-			<plugins>
-				<!-- Build the docker image -->
-				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>0.43.4</version>
-					<configuration>
-						<images>
-							<image>
-								<name>${docker.namespace}/${docker.image.name}</name>
-								<build>
-									<tags>
-										<tag>${docker.image.tag}</tag>
-									</tags>
-									<contextDir>${project.basedir}</contextDir>
-								</build>
-								<run>
-									<ports>
-										<port>
-											${docker.host.port}:${docker.container.port}</port>
-									</ports>
-									<wait>
-										<url>${docker.container.waitForEndpoint}</url>
-										<time>60000</time>
-									</wait>
-									<env>
-										<SPRING_PROFILES_ACTIVE>
-											integration</SPRING_PROFILES_ACTIVE>
-									</env>
-								</run>
-							</image>
-						</images>
-						<verbose>true</verbose>
-					</configuration>
-					<executions>
-						<execution>
-							<id>docker:build</id>
-							<phase>package</phase>
-							<goals>
-								<goal>build</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-up</id>
-							<phase>pre-integration-test</phase>
-							<goals>
-								<goal>start</goal>
-							</goals>
-						</execution>
-						<execution>
-							<id>docker-compose-down</id>
-							<phase>post-integration-test</phase>
-							<goals>
-								<goal>stop</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<profiles>
 		<profile>
 			<id>docker</id>
+      <activation>
+        <property>
+          <name>docker.namespace</name>
+        </property>
+      </activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <run>
+                    <ports>
+                      <port>${docker.host.port}:${docker.container.port}</port>
+                    </ports>
+                    <wait>
+                      <url>${docker.container.waitForEndpoint}</url>
+                      <time>60000</time>
+                    </wait>
+                    <env>
+                      <SPRING_PROFILES_ACTIVE>integration</SPRING_PROFILES_ACTIVE>
+                    </env>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+						<executions>
+							<execution>
+								<id>build-docker</id>
+							</execution>
+							<execution>
+								<id>push-docker</id>
+							</execution>
+							<execution>
+                <id>docker-compose-up</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-compose-down</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+						</executions>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/basyx.submodelservice/basyx.submodelservice.component/pom.xml
+++ b/basyx.submodelservice/basyx.submodelservice.component/pom.xml
@@ -71,18 +71,61 @@
 			</plugin>
 		</plugins>
 	</build>
+
 	<profiles>
 		<profile>
 			<id>docker</id>
+      <activation>
+        <property>
+          <name>docker.namespace</name>
+        </property>
+      </activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <run>
+                    <ports>
+                      <port>${docker.host.port}:${docker.container.port}</port>
+                    </ports>
+                    <wait>
+                      <url>${docker.container.waitForEndpoint}</url>
+                      <time>60000</time>
+                    </wait>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+						<executions>
+							<execution>
+								<id>build-docker</id>
+							</execution>
+							<execution>
+								<id>push-docker</id>
+							</execution>
+							<execution>
+                <id>docker-compose-up</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-compose-down</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+						</executions>
 					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-failsafe-plugin</artifactId>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<revision>2.0.0-SNAPSHOT</revision>
-		<docker.provenance />
-		<docker.namespace>eclipsebasyx</docker.namespace>
-		<docker.image.tag>${revision}</docker.image.tag>
+		<docker.provenance/>
+    <docker.namespace>eclipsebasyx</docker.namespace>
+    <docker.image.name>NOT_DEFINED_IN_MODULE</docker.image.name>
+    <docker.image.tag>${revision}</docker.image.tag>
+    <docker.target.platforms>linux/amd64,linux/arm64</docker.target.platforms>
 		<docker.host.port>8081</docker.host.port>
 		<docker.container.port>8081</docker.container.port>
 		<aas4j-version>1.0.0-milestone-04</aas4j-version>
@@ -158,6 +160,60 @@
 						</execution>
 					</executions>
 				</plugin>
+				<plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.43.4</version>
+          <configuration>
+            <images>
+              <image>
+                <name>${docker.namespace}/${docker.image.name}:${docker.image.tag}</name>
+                <build>
+                  <contextDir>${project.basedir}</contextDir>
+                  <args>
+                  </args>
+                  <labels>
+                    <maven.version>${project.version}</maven.version>
+                    <maven.build.timestamp>${maven.build.timestamp}</maven.build.timestamp>
+                  </labels>
+                  <noCache>true</noCache>
+                </build>
+              </image>
+            </images>
+            <verbose>true</verbose>
+          </configuration>
+          <executions>
+            <execution>
+              <id>build-docker</id>
+              <phase>package</phase>
+              <goals>
+                <goal>build</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>push-docker</id>
+              <phase>deploy</phase>
+              <goals>
+                <goal>build</goal>
+                <goal>push</goal>
+              </goals>
+              <configuration>
+                <images>
+                  <image>
+                    <build>
+                      <buildx>
+                        <platforms>${docker.target.platforms}</platforms>
+                        <attestations>
+                          <provenance>${docker.provenance}</provenance>
+                        </attestations>
+                      </buildx>
+                    </build>
+                  </image>
+                </images>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -218,6 +274,11 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>2.2</version>
+      </dependency>
 			<dependency>
 				<groupId>org.springdoc</groupId>
 				<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>


### PR DESCRIPTION
Included changes:

- One mvn deploy command to deploy all docker images in the repository.
- Unified and simplified `docker-maven-plugin` configuration.
- Allow having different namespace and username. 
- Added missing docker healthcheck.
- Changed wrong java version of registry-aas from 11 to 17.