### PR TITLE
Automate docker image publishing workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,40 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+        cache: maven
+    - name: Install BaSyx
+      run: mvn clean install -DskipTests
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        file: ./Dockerfile
+        push: true
+        tags: repo/repo:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,7 +38,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         file: ./basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
         push: true
-        tags: mhrimaz/basyxtest:cdlatest
+        tags: eclipsebasyx/conceptdescription-repository:latest   
         
     - name: Build and push Submodel Repository Docker image
       uses: docker/build-push-action@v5
@@ -47,7 +47,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         file: ./basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
         push: true
-        tags: mhrimaz/basyxtest:smlatest        
+        tags: eclipsebasyx/submodel-repository:latest        
         
     - name: Build and push Asset Administration Shell Repository Docker image
       uses: docker/build-push-action@v5
@@ -56,7 +56,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         file: ./basyx.aasrepository/basyx.aasrepository.component/Dockerfile
         push: true
-        tags: mhrimaz/basyxtest:aaslatest
+        tags: eclipsebasyx/aas-repository:latest
 
     - name: Build and push AASX File Server Repository Docker image
       uses: docker/build-push-action@v5
@@ -65,7 +65,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         file: ./basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
         push: true
-        tags: mhrimaz/basyxtest:fslatest
+        tags: eclipsebasyx/aasx-file-server-repository:latest
         
     - name: Build and push Environment Docker image
       uses: docker/build-push-action@v5
@@ -74,4 +74,4 @@ jobs:
         platforms: linux/amd64,linux/arm64
         file: ./basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
         push: true
-        tags: mhrimaz/basyxtest:envlatest
+        tags: eclipsebasyx/aas-environment:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,10 +16,10 @@ jobs:
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
         

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,12 +16,13 @@ jobs:
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
+        
     - name: Install BaSyx
       run: mvn clean install -DskipTests
     - name: Log in to Docker Hub
@@ -30,11 +31,47 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
-    - name: Build and push Docker image
+    - name: Build and push Concept Description Repository Docker image
       uses: docker/build-push-action@v5
       with:
         context: ./basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component
         platforms: linux/amd64,linux/arm64
         file: ./basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
         push: true
-        tags: mhrimaz/basyxtest:latest
+        tags: mhrimaz/basyxtest:cdlatest
+        
+    - name: Build and push Submodel Repository Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./basyx.submodelrepository/basyx.submodelrepository.component
+        platforms: linux/amd64,linux/arm64
+        file: ./basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+        push: true
+        tags: mhrimaz/basyxtest:smlatest        
+        
+    - name: Build and push Asset Administration Shell Repository Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./basyx.aasrepository/basyx.aasrepository.component
+        platforms: linux/amd64,linux/arm64
+        file: ./basyx.aasrepository/basyx.aasrepository.component/Dockerfile
+        push: true
+        tags: mhrimaz/basyxtest:aaslatest
+
+    - name: Build and push AASX File Server Repository Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./basyx.aasxfileserver/basyx.aasxfileserver.component
+        platforms: linux/amd64,linux/arm64
+        file: ./basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
+        push: true
+        tags: mhrimaz/basyxtest:fslatest
+        
+    - name: Build and push Environment Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./basyx.aasenvironment/basyx.aasenvironment.component
+        platforms: linux/amd64,linux/arm64
+        file: ./basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
+        push: true
+        tags: mhrimaz/basyxtest:envlatest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Install BaSyx
       run: mvn clean install -DskipTests
@@ -33,8 +33,8 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component
         platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile
+        file: ./basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
         push: true
-        tags: repo/repo:latest
+        tags: mhrimaz/basyxtest:latest


### PR DESCRIPTION
This workflow automatically publish docker images for repositories

- `latest` tag used, for specific version publication, I can further enhance the workflow.
- No test will be runned, since it is assumed that a push on main branch pass previous builds.
- Multi-platform build adds support for arm images as requested in #18 . I briefly tested images on EC2 arm instance. @BlackRose01 or maybe another person can validate more throughly. Images available [in this repository](https://hub.docker.com/repository/docker/mhrimaz/basyxtest) with different tags, I will remove the repository when the pull request accepted
![image](https://github.com/eclipse-basyx/basyx-java-server-sdk/assets/17963017/8bf7a47c-289e-4b36-bdba-e17b7c1dd683)
![image](https://github.com/eclipse-basyx/basyx-java-server-sdk/assets/17963017/5483eed5-9ad7-43b1-a3a7-043909e7b1ec)


@FrankSchnicke 
Since no repository created for AASX file server i choose this name `eclipsebasyx/aasx-file-server-repository`, but you can change.

**Before merging make sure to add docker hub credentials as secret in the repository setting.**