### PR TITLE
Include missing commons-io dependency for AAS Thumbnails implementation

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository.component/pom.xml
+++ b/basyx.aasrepository/basyx.aasrepository.component/pom.xml
@@ -77,7 +77,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
The built jar of `basyx.aasrepository.component`   does not include this dependency. (It was only included for tests)

I stumbled on this when I tested the new thumbnails endpoint running within a docker image. 
<img width="1181" alt="image" src="https://github.com/eclipse-basyx/basyx-java-server-sdk/assets/45067361/7367b8bb-695b-4488-b8d1-8968ad90d22e">

Before:
<img width="732" alt="image" src="https://github.com/eclipse-basyx/basyx-java-server-sdk/assets/45067361/f37cfba8-0e68-4a25-bdfe-8abb2da9616b">

Now:
<img width="732" alt="image" src="https://github.com/eclipse-basyx/basyx-java-server-sdk/assets/45067361/aefe99ca-ba4f-4b43-a41c-ccd2eeba283f">
