### PR TITLE
Add RDF backend to Concept Description repository

### DIFF
--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository-backend-tdb/pom.xml
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository-backend-tdb/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.digitaltwin.basyx</groupId>
+		<artifactId>basyx.conceptdescriptionrepository</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>basyx.conceptdescriptionrepository-backend-tdb</artifactId>
+	<name>Concept Description Repository Backend Triplestore</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.conceptdescriptionrepository-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.12.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.conceptdescriptionrepository-core</artifactId>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.aas4j</groupId>
+			<artifactId>dataformat-json</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository-backend-tdb/src/main/java/org/eclipse/digitaltwin/basyx/conceptdescriptionrepository/TDBConceptDescriptionRepository.java
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository-backend-tdb/src/main/java/org/eclipse/digitaltwin/basyx/conceptdescriptionrepository/TDBConceptDescriptionRepository.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.digitaltwin.basyx.conceptdescriptionrepository;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.SerializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonDeserializer;
+import okhttp3.*;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonSerializer;
+import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
+import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingIdentifierException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.MissingIdentifierException;
+import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
+import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
+
+/**
+ * 
+ * TDB implementation of the ConceptDescriptionRepository
+ *
+ * @author mhrimaz
+ *
+ */
+public class TDBConceptDescriptionRepository implements ConceptDescriptionRepository {
+
+	private String collectionName;
+	private String cdRepositoryName;
+
+	public TDBConceptDescriptionRepository(String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+	public TDBConceptDescriptionRepository(String collectionName, String cdRepositoryName) {
+		this(collectionName);
+		this.cdRepositoryName = cdRepositoryName;
+	}
+
+	@Override
+	public CursorResult<List<ConceptDescription>> getAllConceptDescriptions(PaginationInfo pInfo) {
+		throw new RuntimeException();
+	}
+
+	@Override
+	public CursorResult<List<ConceptDescription>> getAllConceptDescriptionsByIdShort(String idShort, PaginationInfo pInfo) {
+		throw new RuntimeException();
+	}
+
+	@Override
+	public CursorResult<List<ConceptDescription>> getAllConceptDescriptionsByIsCaseOf(Reference reference, PaginationInfo pInfo) {
+		throw new RuntimeException();
+	}
+
+	@Override
+	public CursorResult<List<ConceptDescription>> getAllConceptDescriptionsByDataSpecificationReference(Reference reference, PaginationInfo pInfo) {
+		throw new RuntimeException();
+	}
+
+	@Override
+	public ConceptDescription getConceptDescription(String conceptDescriptionId) throws ElementDoesNotExistException {
+		throw new RuntimeException();
+	}
+
+	@Override
+	public void updateConceptDescription(String conceptDescriptionId, ConceptDescription conceptDescription) throws ElementDoesNotExistException {
+
+		throw new RuntimeException();
+	}
+
+	private static String conceptDescriptionAsRDF(final ConceptDescription conceptDescription) throws SerializationException {
+		// TODO: this should use AAS4j method in the future
+		JsonSerializer jsonSerializer = new JsonSerializer();
+		String conceptDescriptionAsJson = jsonSerializer.write(conceptDescription);
+		OkHttpClient client = new OkHttpClient().newBuilder()
+				.build();
+		MediaType mediaType = MediaType.parse("application/json");
+		RequestBody body = RequestBody.create(mediaType, conceptDescriptionAsJson);
+		Request request = new Request.Builder()
+				.url("http://127.0.0.1:9192/concept-description:jsontordf")
+				.method("POST", body)
+				.addHeader("Content-Type", "application/json")
+				.build();
+		try {
+			Response response = client.newCall(request).execute();
+			String asRDF = response.body().string();
+			String asRDFWithoutPrefixes = asRDF.replaceAll("(?m)^@.*$", "");
+			return asRDFWithoutPrefixes;
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void createConceptDescription(ConceptDescription conceptDescription) throws CollidingIdentifierException, MissingIdentifierException {
+		String conceptDescriptionAsRDF = null;
+		try {
+			conceptDescriptionAsRDF = conceptDescriptionAsRDF(conceptDescription);
+		} catch (SerializationException e) {
+			throw new RuntimeException(e);
+		}
+		OkHttpClient client = new OkHttpClient().newBuilder()
+				.build();
+		MediaType mediaType = MediaType.parse("application/sparql-update");
+		RequestBody body = RequestBody.create(mediaType, "prefix aas: <https://admin-shell.io/aas/3/0/>\r\nprefix xsd: <http://www.w3.org/2001/XMLSchema#>  \r\nINSERT DATA \r\n{"+conceptDescriptionAsRDF+"}");
+		Request request = new Request.Builder()
+				.url("http://127.0.0.1:3030/test/update")
+				.method("POST", body)
+				.addHeader("Content-Type", "application/sparql-update")
+				.build();
+		try {
+			Response response = client.newCall(request).execute();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		throw new RuntimeException();
+	}
+
+	@Override
+	public void deleteConceptDescription(String conceptDescriptionId) throws ElementDoesNotExistException {
+		throw new RuntimeException();
+	}
+
+	@Override
+	public String getName() {
+		return cdRepositoryName == null ? ConceptDescriptionRepository.super.getName() : cdRepositoryName;
+	}
+
+}

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository-backend-tdb/src/main/java/org/eclipse/digitaltwin/basyx/conceptdescriptionrepository/TDBConceptDescriptionRepositoryFactory.java
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository-backend-tdb/src/main/java/org/eclipse/digitaltwin/basyx/conceptdescriptionrepository/TDBConceptDescriptionRepositoryFactory.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.conceptdescriptionrepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+/**
+ * ConceptDescriptionRepository factory returning a TDB backend
+ * ConceptDescriptionRepository
+ * 
+ * @author mhrimaz
+ */
+@Component
+@ConditionalOnExpression("'${basyx.backend}'.equals('tdb')")
+public class TDBConceptDescriptionRepositoryFactory implements ConceptDescriptionRepositoryFactory {
+
+	private String collectionName;
+	private String cdRepositoryName;
+
+	@Autowired(required = false)
+	public TDBConceptDescriptionRepositoryFactory(
+			@Value("${basyx.conceptdescriptionrepository.mongodb.collectionName:conceptdescription-repo}") String collectionName) {
+
+		this.collectionName = collectionName;
+	}
+
+	@Autowired(required = false)
+	public TDBConceptDescriptionRepositoryFactory(
+			@Value("${basyx.conceptdescriptionrepository.mongodb.collectionName:conceptdescription-repo}") String collectionName,
+			@Value("${basyx.cdrepo.name:cd-repo}") String cdRepositoryName) {
+		this(collectionName);
+		this.cdRepositoryName = cdRepositoryName;
+	}
+
+	@Override
+	public ConceptDescriptionRepository create() {
+		return new TDBConceptDescriptionRepository( collectionName, cdRepositoryName);
+	}
+}

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/pom.xml
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/pom.xml
@@ -37,6 +37,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.conceptdescriptionrepository-backend-tdb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.conceptdescriptionrepository-http</artifactId>
 		</dependency>
 

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/src/main/resources/application.properties
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/src/main/resources/application.properties
@@ -2,9 +2,9 @@ server.port=8081
 spring.application.name=Concept Description Repository
 basyx.cdrepo.name = cd-repo
 
-basyx.backend = InMemory
+#basyx.backend = InMemory
 
-#basyx.backend = MongoDB
+basyx.backend = tdb
 #spring.data.mongodb.host=127.0.0.1
 ##or spring.data.mongodb.host=127.0.0.1
 #spring.data.mongodb.port=27017

--- a/basyx.conceptdescriptionrepository/pom.xml
+++ b/basyx.conceptdescriptionrepository/pom.xml
@@ -17,6 +17,7 @@
 		<module>basyx.conceptdescriptionrepository-http</module>
 		<module>basyx.conceptdescriptionrepository-backend-inmemory</module>
 		<module>basyx.conceptdescriptionrepository-backend-mongodb</module>
+		<module>basyx.conceptdescriptionrepository-backend-tdb</module>
 		<module>basyx.conceptdescriptionrepository-tck</module>
 		<module>basyx.conceptdescriptionrepository.component</module>
 	</modules>

--- a/pom.xml
+++ b/pom.xml
@@ -515,6 +515,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.digitaltwin.basyx</groupId>
+				<artifactId>basyx.conceptdescriptionrepository-backend-tdb</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.digitaltwin.basyx</groupId>
 				<artifactId>basyx.conceptdescriptionrepository.component</artifactId>
 				<version>${revision}</version>
 			</dependency>


### PR DESCRIPTION
This pull request will add a new backend to Concept Description repository that uses RDF representation of AAS and stores information in a Triplestore (Apache Jena).
This is the first step towards native RDF-based knowledge graph approach to interact with AAS. Leveraging RDF will allow to run SPARQL queries, SHACL for complex constraint validation, and semantic reasoning.

The exact timeplan will be provided after approval. Followings are the list of tasks. :

- [x] Basic POC and structure
- [ ] Add test cases
- [ ] Impalement CRUD operations
- [ ] Generalize and test with other Triplestores (Ontotext GraphDB)
- [ ] Migrate RDF de-/serialization to AAS4j