### PR TITLE
aas discovery refactoring

### DIFF
--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/backend/mongodb/AasDiscoveryDocument.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/backend/mongodb/AasDiscoveryDocument.java
@@ -1,0 +1,35 @@
+package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.backend.mongodb;
+
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+import java.util.Set;
+
+public class AasDiscoveryDocument {
+	private String shellIdentifier;
+	private Set<AssetLink> assetLinks;
+	private List<SpecificAssetId> specificAssetIds;
+
+	public AasDiscoveryDocument() {
+	}
+
+	public AasDiscoveryDocument(String shellIdentifier, Set<AssetLink> assetLinks, List<SpecificAssetId> specificAssetIds) {
+		this.shellIdentifier = shellIdentifier;
+		this.assetLinks = assetLinks;
+		this.specificAssetIds = specificAssetIds;
+	}
+
+	public String getShellIdentifier() {
+		return shellIdentifier;
+	}
+
+	public Set<AssetLink> getAssetLinks() {
+		return assetLinks;
+	}
+
+	public List<SpecificAssetId> getSpecificAssetIds() {
+		return specificAssetIds;
+	}
+}

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/backend/mongodb/MongoDBAasDiscoveryService.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/backend/mongodb/MongoDBAasDiscoveryService.java
@@ -24,15 +24,13 @@
 
 package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.backend.mongodb;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryService;
+import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryUtils;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
 import org.eclipse.digitaltwin.basyx.core.exceptions.AssetLinkDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingAssetLinkException;
@@ -41,7 +39,9 @@ import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationSupport;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.*;
 import org.springframework.data.mongodb.core.index.Index;
+import org.bson.Document;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -51,13 +51,12 @@ import com.mongodb.client.result.DeleteResult;
  * MongoDB implementation of the {@link AasDiscoveryService}
  *
  * @author danish
- *
  */
 public class MongoDBAasDiscoveryService implements AasDiscoveryService {
 	private static final String SHELL_IDENTIFIER = "shellIdentifier";
-
-	private MongoTemplate mongoTemplate;
-	private String collectionName;
+	private static final String ASSET_LINKS = "assetLinks";
+	private final MongoTemplate mongoTemplate;
+	private final String collectionName;
 	private String aasDiscoveryServiceName;
 
 	public MongoDBAasDiscoveryService(MongoTemplate mongoTemplate, String collectionName) {
@@ -72,47 +71,52 @@ public class MongoDBAasDiscoveryService implements AasDiscoveryService {
 	}
 
 	@Override
-	public CursorResult<List<String>> getAllAssetAdministrationShellIdsByAssetLink(PaginationInfo pInfo, List<String> assetIds) {
-		List<AssetLink> assetLinks = mongoTemplate.findAll(AssetLink.class, collectionName);
+	public CursorResult<List<String>> getAllAssetAdministrationShellIdsByAssetLink(PaginationInfo pInfo, List<AssetLink> assetIds) {
+		MatchOperation matchOperation = Aggregation.match(Criteria.where(ASSET_LINKS).all(assetIds));
+		ProjectionOperation projectionOperation = Aggregation.project(SHELL_IDENTIFIER);
+		GroupOperation groupOperation = Aggregation.group(SHELL_IDENTIFIER);
 
-		Set<String> shellIdentifiers = assetLinks.stream()
-				.filter(link -> containsMatchingAssetId(link.getSpecificAssetIds(), assetIds))
-				.map(AssetLink::getShellIdentifier)
-				.collect(Collectors.toSet());
+		Aggregation aggregation = Aggregation.newAggregation(matchOperation, projectionOperation, groupOperation);
 
-		return paginateList(pInfo, new ArrayList<>(shellIdentifiers));
+		AggregationResults<Document> results = mongoTemplate.aggregate(aggregation, collectionName, Document.class);
+		List<String> shellIds = results.getMappedResults().stream().map(doc -> doc.get("_id").toString()).collect(Collectors.toList());
+
+		return paginateList(pInfo, shellIds);
 	}
 
 	@Override
 	public List<SpecificAssetId> getAllAssetLinksById(String shellIdentifier) {
-		AssetLink assetLink = mongoTemplate.findOne(new Query().addCriteria(Criteria.where(SHELL_IDENTIFIER)
-				.is(shellIdentifier)), AssetLink.class, collectionName);
+		AasDiscoveryDocument document = mongoTemplate.findOne(getSingleObjectQuery(shellIdentifier), AasDiscoveryDocument.class, collectionName);
 
-		if (assetLink == null)
+		if (document == null)
 			throw new AssetLinkDoesNotExistException(shellIdentifier);
 
-		return assetLink.getSpecificAssetIds();
+		return document.getSpecificAssetIds();
 	}
 
 	@Override
 	public List<SpecificAssetId> createAllAssetLinksById(String shellIdentifier, List<SpecificAssetId> assetIds) {
-		Query query = new Query().addCriteria(Criteria.where(SHELL_IDENTIFIER)
-				.is(shellIdentifier));
+		Query query = getSingleObjectQuery(shellIdentifier);
 
-		if (mongoTemplate.exists(query, AssetLink.class, collectionName))
+		if (mongoTemplate.exists(query, AasDiscoveryDocument.class, collectionName))
 			throw new CollidingAssetLinkException(shellIdentifier);
 
-		AssetLink link = new AssetLink(shellIdentifier, assetIds);
+		Set<AssetLink> assetLinks = new HashSet<>(AasDiscoveryUtils.deriveAssetLinksFromSpecificAssetIds(assetIds));
 
-		mongoTemplate.save(link, collectionName);
+		AasDiscoveryDocument document = new AasDiscoveryDocument(shellIdentifier, assetLinks, assetIds);
+
+		mongoTemplate.save(document, collectionName);
 
 		return assetIds;
 	}
 
+	private static Query getSingleObjectQuery(String shellIdentifier) {
+		return new Query().addCriteria(Criteria.where(SHELL_IDENTIFIER).is(shellIdentifier));
+	}
+
 	@Override
 	public void deleteAllAssetLinksById(String shellIdentifier) {
-		Query query = new Query().addCriteria(Criteria.where(SHELL_IDENTIFIER)
-				.is(shellIdentifier));
+		Query query = getSingleObjectQuery(shellIdentifier);
 
 		DeleteResult result = mongoTemplate.remove(query, AssetLink.class, collectionName);
 
@@ -132,13 +136,6 @@ public class MongoDBAasDiscoveryService implements AasDiscoveryService {
 		PaginationSupport<String> paginationSupport = new PaginationSupport<>(shellIdentifierMap, Function.identity());
 
 		return paginationSupport.getPaged(pInfo);
-	}
-
-	private boolean containsMatchingAssetId(List<SpecificAssetId> containedSpecificAssetIds, List<String> queryAssetIds) {
-		return queryAssetIds.stream()
-				.anyMatch(queryAssetId -> containedSpecificAssetIds.stream()
-						.anyMatch(containedAssetId -> containedAssetId.getValue()
-								.equals(queryAssetId)));
 	}
 
 	private void configureIndexForConceptDescriptionId(MongoTemplate mongoTemplate) {

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-backend-mongodb/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/backend/mongodb/TestMongoDBAasDiscoveryService.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-backend-mongodb/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/backend/mongodb/TestMongoDBAasDiscoveryService.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryService;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryServiceSuite;
@@ -87,7 +88,7 @@ public class TestMongoDBAasDiscoveryService extends AasDiscoveryServiceSuite {
 	}
 
 	private List<SpecificAssetId> createDummyAssetLinkOnDiscoveryService(String testShellIdentifier, AasDiscoveryService aasDiscoveryService) {
-		AssetLink assetLink = getSingleDummyAasAssetLink(testShellIdentifier);
+		AssetAdministrationShell assetLink = getSingleDummyAasAssetLink(testShellIdentifier);
 		createAssetLink(assetLink, aasDiscoveryService);
 
 		SpecificAssetId specificAssetId_1 = createDummySpecificAssetId("TestAsset1", "TestAssetValue1");

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/core/AasDiscoveryService.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/core/AasDiscoveryService.java
@@ -28,6 +28,7 @@ package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core;
 import java.util.List;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 
@@ -46,13 +47,13 @@ public interface AasDiscoveryService {
 	 * @param assetIds
 	 * @return a list of all matching Aas Ids
 	 */
-	public CursorResult<List<String>> getAllAssetAdministrationShellIdsByAssetLink(PaginationInfo pInfo, List<String> assetIds);
+	public CursorResult<List<String>> getAllAssetAdministrationShellIdsByAssetLink(PaginationInfo pInfo, List<AssetLink> assetIds);
 
 	/**
 	 * Returns a list of asset identifier key-value-pairs based on an Asset
 	 * Administration Shell id
 	 * 
-	 * @param aasIdentifier
+	 * @param shellIdentifier
 	 * @return a list of asset identifiers
 	 */
 	public List<SpecificAssetId> getAllAssetLinksById(String shellIdentifier);
@@ -62,7 +63,7 @@ public interface AasDiscoveryService {
 	 * Administration Shell for discoverable content. The existing content might
 	 * have to be deleted first.
 	 * 
-	 * @param aasIdentifier
+	 * @param shellIdentifier
 	 * @param assetIds
 	 * @return a list of asset identifiers
 	 */
@@ -72,7 +73,7 @@ public interface AasDiscoveryService {
 	 * Deletes all asset identifier key-value-pairs linked to an Asset
 	 * Administration Shell
 	 * 
-	 * @param aasIdentifier
+	 * @param shellIdentifier
 	 */
 	public void deleteAllAssetLinksById(String shellIdentifier);
 

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/core/AasDiscoveryUtils.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/core/AasDiscoveryUtils.java
@@ -1,0 +1,31 @@
+package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core;
+
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetInformation;
+import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AasDiscoveryUtils {
+
+	public static List<AssetLink> deriveAssetLinksFromShell(AssetAdministrationShell shell) {
+		List<SpecificAssetId> specificAssetIds = shell.getAssetInformation().getSpecificAssetIds();
+
+		return deriveAssetLinksFromSpecificAssetIds(specificAssetIds);
+	}
+
+	public static List<AssetLink> deriveAssetLinksFromSpecificAssetIds(List<SpecificAssetId> specificAssetIds) {
+		List<AssetLink> assetLinks = new ArrayList<>();
+		specificAssetIds.forEach(assetId -> assetLinks.add(new AssetLink(assetId.getName(), assetId.getValue())));
+		return assetLinks;
+	}
+
+	public static AssetAdministrationShell deriveShellFromIdAndSpecificAssetIds(String shellId, List<SpecificAssetId> specificAssetIds) {
+		DefaultAssetInformation assetInformation = new DefaultAssetInformation.Builder().specificAssetIds(specificAssetIds).build();
+
+		return new DefaultAssetAdministrationShell.Builder().id(shellId).assetInformation(assetInformation).build();
+	}
+}

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/core/model/AssetLink.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/core/model/AssetLink.java
@@ -26,6 +26,7 @@
 package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
@@ -40,26 +41,45 @@ import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
  */
 public class AssetLink {
 
-	private String shellIdentifier;
-	private List<SpecificAssetId> specificAssetIds;
+	private String name;
+	private String value;
 
-	public AssetLink(String shellIdentifier, List<SpecificAssetId> specificAssetIds) {
-		super();
-		this.shellIdentifier = shellIdentifier;
-		this.specificAssetIds = specificAssetIds;
+	public AssetLink() {
 	}
 
-	public String getShellIdentifier() {
-		return shellIdentifier;
+	public AssetLink(String name, String value) {
+		this.name = name;
+		this.value = value;
 	}
 
-	public List<SpecificAssetId> getSpecificAssetIds() {
-		return specificAssetIds;
+	public String getName() {
+		return name;
 	}
 
-	public List<String> getSpecificAssetIdStrings() {
-		return specificAssetIds.stream()
-				.map(SpecificAssetId::getValue)
-				.collect(Collectors.toList());
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		AssetLink assetLink = (AssetLink) o;
+		return Objects.equals(name, assetLink.name) && Objects.equals(value, assetLink.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, value);
 	}
 }

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/LookupApi.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/LookupApi.java
@@ -47,66 +47,68 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 
-@jakarta.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2023-10-10T10:16:17.046754509Z[GMT]")
+@Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2023-10-10T10:16:17.046754509Z[GMT]")
 @Validated
 public interface LookupApi {
-	@Operation(summary = "Deletes all specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "204", description = "Specific Asset identifiers deleted successfully"),
 
-			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+    @Operation(summary = "Deletes all specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "Specific Asset identifiers deleted successfully"),
 
-			@ApiResponse(responseCode = "200", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-	@RequestMapping(value = "/lookup/shells/{aasIdentifier}",
-			produces = { "application/json" },
-			method = RequestMethod.DELETE)
-	ResponseEntity<Void> deleteAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
+        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-
-	@Operation(summary = "Returns a list of Asset Administration Shell ids linked to specific Asset identifiers", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Requested Asset Administration Shell ids", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InlineResponse200.class))),
-
-			@ApiResponse(responseCode = "200", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-	@RequestMapping(value = "/lookup/shells",
-			produces = { "application/json" },
-			method = RequestMethod.GET)
-	ResponseEntity<PagedResult> getAllAssetAdministrationShellIdsByAssetLink(@Parameter(in = ParameterIn.QUERY, description = "A list of specific Asset identifiers. Each Asset identifier is a base64-url-encoded [SpecificAssetId](https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0.1#/components/schemas/SpecificAssetId)" ,schema=@Schema()) @Valid @RequestParam(value = "assetIds", required = false) List<Base64UrlEncodedIdentifier> assetIds, @Min(1)@Parameter(in = ParameterIn.QUERY, description = "The maximum number of elements in the response array" ,schema=@Schema(allowableValues={ "1" }, minimum="1"
-	)) @Valid @RequestParam(value = "limit", required = false) Integer limit, @Parameter(in = ParameterIn.QUERY, description = "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue" ,schema=@Schema()) @Valid @RequestParam(value = "cursor", required = false) String cursor);
+        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+    @RequestMapping(value = "/lookup/shells/{aasIdentifier}",
+        produces = { "application/json" },
+        method = RequestMethod.DELETE)
+    ResponseEntity<Void> deleteAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
 
 
-	@Operation(summary = "Returns a list of specific Asset identifiers based on an Asset Administration Shell id to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Requested specific Asset identifiers", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
+    @Operation(summary = "Returns a list of Asset Administration Shell ids linked to specific Asset identifiers", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Requested Asset Administration Shell ids", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InlineResponse200.class))),
 
-			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+    @RequestMapping(value = "/lookup/shells",
+        produces = { "application/json" },
+        method = RequestMethod.GET)
+    ResponseEntity<PagedResult> getAllAssetAdministrationShellIdsByAssetLink(@Parameter(in = ParameterIn.QUERY, description = "A list of specific Asset identifiers. Each Asset identifier is a base64-url-encoded [SpecificAssetId](https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0.1#/components/schemas/SpecificAssetId)" ,schema=@Schema()) @Valid @RequestParam(value = "assetIds", required = false) List<Base64UrlEncodedIdentifier> assetIds, @Min(1)@Parameter(in = ParameterIn.QUERY, description = "The maximum number of elements in the response array" ,schema=@Schema(allowableValues={ "1" }, minimum="1"
+)) @Valid @RequestParam(value = "limit", required = false) Integer limit, @Parameter(in = ParameterIn.QUERY, description = "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue" ,schema=@Schema()) @Valid @RequestParam(value = "cursor", required = false) String cursor);
 
-			@ApiResponse(responseCode = "200", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-	@RequestMapping(value = "/lookup/shells/{aasIdentifier}",
-			produces = { "application/json" },
-			method = RequestMethod.GET)
-	ResponseEntity<List<SpecificAssetId>> getAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
+
+    @Operation(summary = "Returns a list of specific Asset identifiers based on an Asset Administration Shell id to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Requested specific Asset identifiers", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
+
+        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+
+        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+    @RequestMapping(value = "/lookup/shells/{aasIdentifier}",
+        produces = { "application/json" },
+        method = RequestMethod.GET)
+    ResponseEntity<List<SpecificAssetId>> getAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
 
 
-	@Operation(summary = "Creates specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "201", description = "Specific Asset identifiers created successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
+    @Operation(summary = "Creates specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Specific Asset identifiers created successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
 
-			@ApiResponse(responseCode = "400", description = "Bad Request, e.g. the request parameters of the format of the request body is wrong.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+        @ApiResponse(responseCode = "400", description = "Bad Request, e.g. the request parameters of the format of the request body is wrong.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-			@ApiResponse(responseCode = "409", description = "Conflict, a resource which shall be created exists already. Might be thrown if a Submodel or SubmodelElement with the same ShortId is contained in a POST request.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+        @ApiResponse(responseCode = "409", description = "Conflict, a resource which shall be created exists already. Might be thrown if a Submodel or SubmodelElement with the same ShortId is contained in a POST request.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-			@ApiResponse(responseCode = "200", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-	@RequestMapping(value = "/lookup/shells/{aasIdentifier}",
-			produces = { "application/json" },
-			consumes = { "application/json" },
-			method = RequestMethod.POST)
-	ResponseEntity<List<SpecificAssetId>> postAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier, @Parameter(in = ParameterIn.DEFAULT, description = "A list of specific Asset identifiers", required=true, schema=@Schema()) @Valid @RequestBody List<SpecificAssetId> body);
-
+        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+    @RequestMapping(value = "/lookup/shells/{aasIdentifier}",
+        produces = { "application/json" },
+        consumes = { "application/json" },
+        method = RequestMethod.POST)
+    ResponseEntity<List<SpecificAssetId>> postAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier, @Parameter(in = ParameterIn.DEFAULT, description = "A list of specific Asset identifiers", required=true, schema=@Schema()) @Valid @RequestBody List<SpecificAssetId> body);
 }
+

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/LookupApi.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/LookupApi.java
@@ -55,60 +55,59 @@ import java.util.List;
 @Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2023-10-10T10:16:17.046754509Z[GMT]")
 @Validated
 public interface LookupApi {
+	@Operation(summary = "Deletes all specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "Specific Asset identifiers deleted successfully"),
 
-    @Operation(summary = "Deletes all specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "Specific Asset identifiers deleted successfully"),
+			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
-
-        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-    @RequestMapping(value = "/lookup/shells/{aasIdentifier}",
-        produces = { "application/json" },
-        method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
-
-
-    @Operation(summary = "Returns a list of Asset Administration Shell ids linked to specific Asset identifiers", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Requested Asset Administration Shell ids", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InlineResponse200.class))),
-
-        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-    @RequestMapping(value = "/lookup/shells",
-        produces = { "application/json" },
-        method = RequestMethod.GET)
-    ResponseEntity<PagedResult> getAllAssetAdministrationShellIdsByAssetLink(@Parameter(in = ParameterIn.QUERY, description = "A list of specific Asset identifiers. Each Asset identifier is a base64-url-encoded [SpecificAssetId](https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0.1#/components/schemas/SpecificAssetId)" ,schema=@Schema()) @Valid @RequestParam(value = "assetIds", required = false) List<Base64UrlEncodedIdentifier> assetIds, @Min(1)@Parameter(in = ParameterIn.QUERY, description = "The maximum number of elements in the response array" ,schema=@Schema(allowableValues={ "1" }, minimum="1"
-)) @Valid @RequestParam(value = "limit", required = false) Integer limit, @Parameter(in = ParameterIn.QUERY, description = "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue" ,schema=@Schema()) @Valid @RequestParam(value = "cursor", required = false) String cursor);
+			@ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+	@RequestMapping(value = "/lookup/shells/{aasIdentifier}",
+			produces = { "application/json" },
+			method = RequestMethod.DELETE)
+	ResponseEntity<Void> deleteAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
 
 
-    @Operation(summary = "Returns a list of specific Asset identifiers based on an Asset Administration Shell id to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Requested specific Asset identifiers", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
+	@Operation(summary = "Returns a list of Asset Administration Shell ids linked to specific Asset identifiers", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Requested Asset Administration Shell ids", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InlineResponse200.class))),
 
-        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+			@ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+	@RequestMapping(value = "/lookup/shells",
+			produces = { "application/json" },
+			method = RequestMethod.GET)
+	ResponseEntity<PagedResult> getAllAssetAdministrationShellIdsByAssetLink(@Parameter(in = ParameterIn.QUERY, description = "A list of specific Asset identifiers. Each Asset identifier is a base64-url-encoded [SpecificAssetId](https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0.1#/components/schemas/SpecificAssetId)" ,schema=@Schema()) @Valid @RequestParam(value = "assetIds", required = false) List<Base64UrlEncodedIdentifier> assetIds, @Min(1)@Parameter(in = ParameterIn.QUERY, description = "The maximum number of elements in the response array" ,schema=@Schema(allowableValues={ "1" }, minimum="1"
+	)) @Valid @RequestParam(value = "limit", required = false) Integer limit, @Parameter(in = ParameterIn.QUERY, description = "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue" ,schema=@Schema()) @Valid @RequestParam(value = "cursor", required = false) String cursor);
 
-        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-    @RequestMapping(value = "/lookup/shells/{aasIdentifier}",
-        produces = { "application/json" },
-        method = RequestMethod.GET)
-    ResponseEntity<List<SpecificAssetId>> getAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
+
+	@Operation(summary = "Returns a list of specific Asset identifiers based on an Asset Administration Shell id to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Requested specific Asset identifiers", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
+
+			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+
+			@ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+	@RequestMapping(value = "/lookup/shells/{aasIdentifier}",
+			produces = { "application/json" },
+			method = RequestMethod.GET)
+	ResponseEntity<List<SpecificAssetId>> getAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier);
 
 
-    @Operation(summary = "Creates specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "Specific Asset identifiers created successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
+	@Operation(summary = "Creates specific Asset identifiers linked to an Asset Administration Shell to edit discoverable content", description = "", tags={ "Asset Administration Shell Basic Discovery API" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "201", description = "Specific Asset identifiers created successfully", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = SpecificAssetId.class)))),
 
-        @ApiResponse(responseCode = "400", description = "Bad Request, e.g. the request parameters of the format of the request body is wrong.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+			@ApiResponse(responseCode = "400", description = "Bad Request, e.g. the request parameters of the format of the request body is wrong.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-        @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-        @ApiResponse(responseCode = "409", description = "Conflict, a resource which shall be created exists already. Might be thrown if a Submodel or SubmodelElement with the same ShortId is contained in a POST request.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
+			@ApiResponse(responseCode = "409", description = "Conflict, a resource which shall be created exists already. Might be thrown if a Submodel or SubmodelElement with the same ShortId is contained in a POST request.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))),
 
-        @ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
-    @RequestMapping(value = "/lookup/shells/{aasIdentifier}",
-        produces = { "application/json" },
-        consumes = { "application/json" },
-        method = RequestMethod.POST)
-    ResponseEntity<List<SpecificAssetId>> postAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier, @Parameter(in = ParameterIn.DEFAULT, description = "A list of specific Asset identifiers", required=true, schema=@Schema()) @Valid @RequestBody List<SpecificAssetId> body);
+			@ApiResponse(responseCode = "default", description = "Default error handling for unmentioned status codes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Result.class))) })
+	@RequestMapping(value = "/lookup/shells/{aasIdentifier}",
+			produces = { "application/json" },
+			consumes = { "application/json" },
+			method = RequestMethod.POST)
+	ResponseEntity<List<SpecificAssetId>> postAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier, @Parameter(in = ParameterIn.DEFAULT, description = "A list of specific Asset identifiers", required=true, schema=@Schema()) @Valid @RequestBody List<SpecificAssetId> body);
+
 }
-

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/LookupApiController.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/LookupApiController.java
@@ -25,12 +25,12 @@
 
 package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.http;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryService;
+import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.http.pagination.InlineResponse200;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
@@ -40,54 +40,59 @@ import org.eclipse.digitaltwin.basyx.http.pagination.PagedResultPagingMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Min;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-@jakarta.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2023-10-10T10:16:17.046754509Z[GMT]")
+@Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2023-10-10T10:16:17.046754509Z[GMT]")
 @RestController
 public class LookupApiController implements LookupApi {
 
-	private final AasDiscoveryService aasDiscoveryService;
+    private final AasDiscoveryService aasDiscoveryService;
+	private final ObjectMapper objectMapper;
 
-	@Autowired
-	public LookupApiController(AasDiscoveryService aasDiscoveryService) {
-		this.aasDiscoveryService = aasDiscoveryService;
-	}
+    @Autowired
+    public LookupApiController(AasDiscoveryService aasDiscoveryService, ObjectMapper objectMapper) {
+    	this.aasDiscoveryService = aasDiscoveryService;
+		this.objectMapper = objectMapper;
+    }
 
-	public ResponseEntity<Void> deleteAllAssetLinksById(
-			@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required = true, schema = @Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier) {
-		aasDiscoveryService.deleteAllAssetLinksById(aasIdentifier.getIdentifier());
+    public ResponseEntity<Void> deleteAllAssetLinksById(@Parameter(in = ParameterIn.PATH, description = "The Asset Administration Shell’s unique id (UTF8-BASE64-URL-encoded)", required=true, schema=@Schema()) @PathVariable("aasIdentifier") Base64UrlEncodedIdentifier aasIdentifier) {
+    	aasDiscoveryService.deleteAllAssetLinksById(aasIdentifier.getIdentifier());
 
 		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
-	}
+    }
 
-	public ResponseEntity<PagedResult> getAllAssetAdministrationShellIdsByAssetLink(
-			@Parameter(in = ParameterIn.QUERY, description = "A list of specific Asset identifiers. Each Asset identifier is a base64-url-encoded [SpecificAssetId](https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0.1#/components/schemas/SpecificAssetId)", schema = @Schema()) @Valid @RequestParam(value = "assetIds", required = false) List<Base64UrlEncodedIdentifier> assetIds,
-			@Min(1) @Parameter(in = ParameterIn.QUERY, description = "The maximum number of elements in the response array", schema = @Schema(allowableValues = {
-					"1" }, minimum = "1")) @Valid @RequestParam(value = "limit", required = false) Integer limit,
-			@Parameter(in = ParameterIn.QUERY, description = "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue", schema = @Schema()) @Valid @RequestParam(value = "cursor", required = false) String cursor) {
+    public ResponseEntity<PagedResult> getAllAssetAdministrationShellIdsByAssetLink(@Parameter(in = ParameterIn.QUERY, description = "A list of specific Asset identifiers. Each Asset identifier is a base64-url-encoded [SpecificAssetId](https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0.1#/components/schemas/SpecificAssetId)" ,schema=@Schema()) @Valid @RequestParam(value = "assetIds", required = false) List<Base64UrlEncodedIdentifier> assetIds,@Min(1)@Parameter(in = ParameterIn.QUERY, description = "The maximum number of elements in the response array" ,schema=@Schema(allowableValues={ "1" }, minimum="1"
+)) @Valid @RequestParam(value = "limit", required = false) Integer limit,@Parameter(in = ParameterIn.QUERY, description = "A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue" ,schema=@Schema()) @Valid @RequestParam(value = "cursor", required = false) String cursor) {
 
-		if (limit == null) {
+    	if (limit == null)
 			limit = 100;
-		}
 
-		if (cursor == null) {
+		if (cursor == null)
 			cursor = "";
-		}
 
 		PaginationInfo pInfo = new PaginationInfo(limit, cursor);
 
-		List<String> decodedAssetIds = getDecodedAssetIds(assetIds);
+		List<AssetLink> decodedAssetLinks;
+		try {
+			decodedAssetLinks = getDecodedAssetLinks(assetIds);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
 
-		CursorResult<List<String>> filteredResult = aasDiscoveryService.getAllAssetAdministrationShellIdsByAssetLink(pInfo, decodedAssetIds);
+		CursorResult<List<String>> filteredResult = aasDiscoveryService.getAllAssetAdministrationShellIdsByAssetLink(pInfo, decodedAssetLinks);
 
 		InlineResponse200 paginatedAasIds = new InlineResponse200();
 		paginatedAasIds.setResult(filteredResult.getResult());
@@ -107,14 +112,20 @@ public class LookupApiController implements LookupApi {
         
         return new ResponseEntity<List<SpecificAssetId>>(assetIDs, HttpStatus.CREATED);
     }
-    
-	private List<String> getDecodedAssetIds(List<Base64UrlEncodedIdentifier> assetIds) {
 
-		if (assetIds == null) {
-			return new ArrayList<>();
+	private List<AssetLink> getDecodedAssetLinks(List<Base64UrlEncodedIdentifier> assetIds) throws JsonProcessingException {
+		List<AssetLink> result = new ArrayList<>();
+
+		if (assetIds == null)
+			return result;
+
+		for (Base64UrlEncodedIdentifier base64Hack : assetIds) {
+
+			var decodedString = base64Hack.getIdentifier();
+				result.add(objectMapper.readValue(decodedString, AssetLink.class));
+
 		}
-
-		return assetIds.stream().map(assetId -> assetId.getIdentifier()).collect(Collectors.toList());
+		return result;
 	}
 
 }

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/AasDiscoveryServiceHTTPSuite.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/AasDiscoveryServiceHTTPSuite.java
@@ -57,15 +57,6 @@ public abstract class AasDiscoveryServiceHTTPSuite {
 	public abstract void resetService();
 
 	@Test
-	public void getAllAssetAdministrationShellIdsByAssetLink() throws ParseException, IOException {
-		String expectedShellIds = getAllShellIdsJSON();
-
-		String actualShellIds = requestAllShellIds();
-
-		BaSyxHttpTestUtils.assertSameJSONContent(expectedShellIds, getJSONWithoutCursorInfo(actualShellIds));
-	}
-
-	@Test
 	public void getAllAssetLinks() throws IOException, ParseException {
 		String expectedShellIds = getAllAssetLinksJSON();
 
@@ -131,12 +122,6 @@ public abstract class AasDiscoveryServiceHTTPSuite {
 
 	protected CloseableHttpResponse deleteAssetLinkById(String shellId) throws IOException {
 		return removeAssetLink(shellId);
-	}
-
-	protected String requestAllShellIds() throws IOException, ParseException {
-		CloseableHttpResponse response = BaSyxHttpTestUtils.executeGetOnURL(getURL() + "?assetIds=RHVtbXlBc3NldF8xX1ZhbHVl,RHVtbXlBc3NldF8zX1ZhbHVl");
-
-		return BaSyxHttpTestUtils.getResponseAsString(response);
 	}
 
 	protected CloseableHttpResponse requestAllAssetLinks(String shellIdentifier) throws IOException, ParseException {

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/TestAasDiscoveryServiceHTTP.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-http/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/http/TestAasDiscoveryServiceHTTP.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryService;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryServiceSuite;
+import static org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryUtils.deriveAssetLinksFromShell;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
 import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingAssetLinkException;
 import org.junit.AfterClass;
@@ -56,19 +57,20 @@ public class TestAasDiscoveryServiceHTTP extends AasDiscoveryServiceHTTPSuite {
 	public void resetService() {
 		AasDiscoveryService aasDiscoveryService = appContext.getBean(AasDiscoveryService.class);
 
-		List<AssetLink> dummyAssetLinks = AasDiscoveryServiceSuite.getMultipleDummyAasAssetLink();
+		List<AssetAdministrationShell> dummyAssetLinks = AasDiscoveryServiceSuite.getMultipleDummyAasAssetLink();
 
 		dummyAssetLinks.stream()
 				.forEach(assetLink -> resetAssetLink(assetLink, aasDiscoveryService));
 	}
 
-	private void resetAssetLink(AssetLink assetLink, AasDiscoveryService aasDiscoveryService) {
+	private void resetAssetLink(AssetAdministrationShell shell, AasDiscoveryService aasDiscoveryService) {
 
+		List<AssetLink> linksFromShell = deriveAssetLinksFromShell(shell);
 		try {
-			aasDiscoveryService.createAllAssetLinksById(assetLink.getShellIdentifier(), assetLink.getSpecificAssetIds());
+			aasDiscoveryService.createAllAssetLinksById(shell.getId(), shell.getAssetInformation().getSpecificAssetIds());
 		} catch (CollidingAssetLinkException e) {
-			aasDiscoveryService.deleteAllAssetLinksById(assetLink.getShellIdentifier());
-			aasDiscoveryService.createAllAssetLinksById(assetLink.getShellIdentifier(), assetLink.getSpecificAssetIds());
+			aasDiscoveryService.deleteAllAssetLinksById(shell.getId());
+			aasDiscoveryService.createAllAssetLinksById(shell.getId(), shell.getAssetInformation().getSpecificAssetIds());
 		}
 	}
 

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-tck/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/tck/AasDiscoveryServiceTestDefinedURL.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-tck/src/test/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/tck/AasDiscoveryServiceTestDefinedURL.java
@@ -24,20 +24,20 @@
  ******************************************************************************/
 package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.tck;
 
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.util.List;
-
+import com.google.gson.Gson;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ParseException;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.AasDiscoveryServiceSuite;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.core.model.AssetLink;
 import org.eclipse.digitaltwin.basyx.aasdiscoveryservice.http.AasDiscoveryServiceHTTPSuite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.fail;
 
 /**
  * 
@@ -61,30 +61,30 @@ public class AasDiscoveryServiceTestDefinedURL extends AasDiscoveryServiceHTTPSu
 	}
 
 	private void createDummyAssetLinks() {
-		List<AssetLink> dummyAssetLinks = AasDiscoveryServiceSuite.getMultipleDummyAasAssetLink();
+		List<AssetAdministrationShell> dummyAssetLinks = AasDiscoveryServiceSuite.getMultipleDummyAasAssetLink();
 		dummyAssetLinks.forEach(this::createAssetLink);
 	}
 
-	private void createAssetLink(AssetLink assetLink) {
+	private void createAssetLink(AssetAdministrationShell shell) {
 		try {
-			String specificAssetIdsJSON = gson.toJson(assetLink.getSpecificAssetIds());
-			CloseableHttpResponse creationResponse = createAssetLinks(assetLink.getShellIdentifier(), specificAssetIdsJSON);
+			String specificAssetIdsJSON = gson.toJson(shell.getAssetInformation().getSpecificAssetIds());
+			CloseableHttpResponse creationResponse = createAssetLinks(shell.getId(), specificAssetIdsJSON);
 
 			if (creationResponse.getCode() != 409) {
-				logger.info("Creating Asset Link with shell id '{}', ResponseCode is '{}'", assetLink.getShellIdentifier(), creationResponse.getCode());
+				logger.info("Creating Asset Link with shell id '{}', ResponseCode is '{}'", shell.getId(), creationResponse.getCode());
 				return;
 			}
 
-			resetAssetLink(assetLink);
+			resetAssetLink(shell);
 		} catch (IOException | ParseException e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	private void resetAssetLink(AssetLink assetLink) {
-		deleteAssetLink(assetLink.getShellIdentifier());
+	private void resetAssetLink(AssetAdministrationShell shell) {
+		deleteAssetLink(shell.getId());
 
-		createAssetLink(assetLink);
+		createAssetLink(shell);
 	}
 
 	private void deleteAssetLink(String shellId) {

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11
+FROM amazoncorretto:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/pom.xml
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/pom.xml
@@ -14,8 +14,7 @@
 
 	<properties>
 		<docker.image.name>aas-discovery</docker.image.name>
-		<docker.container.waitForEndpoint>
-			http://localhost:${docker.host.port}/lookup/shells</docker.container.waitForEndpoint>
+		<docker.container.waitForEndpoint>http://localhost:${docker.host.port}/lookup/shells</docker.container.waitForEndpoint>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Adjustments after discussing the purpose of aas discovery in idta workstream "rest api".

In general - the assetIds provided in get-request must be AND connected - not OR.