### PR TITLE
Add inner throwable (cause of the runtime exception) to repository integration exceptions

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
@@ -134,9 +134,7 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 			logger.info("Shell '{}' has been automatically linked with the Registry", shell.getId());
 		} catch (ApiException e) {
-			e.printStackTrace();
-
-			throw new RepositoryRegistryLinkException(shell.getId());
+			throw new RepositoryRegistryLinkException(shell.getId(), e);
 		}
 	}
 
@@ -154,9 +152,7 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 			logger.info("Shell '{}' has been automatically un-linked from the Registry.", shellId);
 		} catch (ApiException e) {
-			e.printStackTrace();
-
-			throw new RepositoryRegistryUnlinkException(shellId);
+			throw new RepositoryRegistryUnlinkException(shellId, e);
 		}
 	}
 	

--- a/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryLinkException.java
+++ b/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryLinkException.java
@@ -33,11 +33,10 @@ package org.eclipse.digitaltwin.basyx.core.exceptions;
  */
 @SuppressWarnings("serial")
 public class RepositoryRegistryLinkException extends RuntimeException {
-	public RepositoryRegistryLinkException() {
-	}
 
-	public RepositoryRegistryLinkException(String id) {
-		super(getMessage(id));
+
+	public RepositoryRegistryLinkException(String id, Throwable th) {
+		super(getMessage(id), th);
 	}
 
 	private static String getMessage(String id) {

--- a/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryUnlinkException.java
+++ b/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryUnlinkException.java
@@ -33,11 +33,9 @@ package org.eclipse.digitaltwin.basyx.core.exceptions;
  */
 @SuppressWarnings("serial")
 public class RepositoryRegistryUnlinkException extends RuntimeException {
-	public RepositoryRegistryUnlinkException() {
-	}
 
-	public RepositoryRegistryUnlinkException(String id) {
-		super(getMessage(id));
+	public RepositoryRegistryUnlinkException(String id, Throwable th) {
+		super(getMessage(id), th);
 	}
 
 	private static String getMessage(String id) {

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
@@ -172,9 +172,7 @@ public class RegistryIntegrationSubmodelRepository implements SubmodelRepository
 
 			logger.info("Submodel '{}' has been automatically linked with the Registry", submodel.getId());
 		} catch (ApiException e) {
-			e.printStackTrace();
-
-			throw new RepositoryRegistryLinkException(submodel.getId());
+			throw new RepositoryRegistryLinkException(submodel.getId(), e);
 		}
 	}
 
@@ -192,9 +190,7 @@ public class RegistryIntegrationSubmodelRepository implements SubmodelRepository
 
 			logger.info("Submodel '{}' has been automatically un-linked from the Registry.", submodelId);
 		} catch (ApiException e) {
-			e.printStackTrace();
-
-			throw new RepositoryRegistryUnlinkException(submodelId);
+			throw new RepositoryRegistryUnlinkException(submodelId, e);
 		}
 	}
 	


### PR DESCRIPTION
Otherwise we could not see why the exception occurred

ex.printStacktrace() is not working. We need to use the logger or put it as "cause" to the runtime exception as done here