### PR TITLE
First development step aasregistry authorization feature

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/Readme.md
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/Readme.md
@@ -1,0 +1,68 @@
+# AssetAdministrationShell Registry - Authorization
+This feature enables authorized access to the AssetAdministrationShell Registry.
+
+To enable this feature, the following properties should be configured:
+
+```
+basyx.feature.authorization.enabled = true
+basyx.feature.authorization.type = <The type of authorization to enable>
+basyx.feature.authorization.jwtBearerTokenProvider = <The Jwt token provider>
+basyx.feature.authorization.rbac.file = <Class path of the Rbac rules file if authorization type is rbac>
+spring.security.oauth2.resourceserver.jwt.issuer-uri= <URI of the resource server>
+```
+
+Note: Only Role Based Access Control (RBAC) is supported as authorization type as of now, also Keycloak is the only Jwt token provider supported now and it is also a default provider. 
+
+To know more about the RBAC, please refer [Authorization Services Guide](https://www.keycloak.org/docs/latest/authorization_services/index.html)
+To know more about the Keycloak server administration, please refer [Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/#keycloak-features-and-concepts)
+
+An example valid configuration:
+
+```
+basyx.feature.authorization.enabled = true
+basyx.feature.authorization.type = rbac
+basyx.feature.authorization.jwtBearerTokenProvider = keycloak
+basyx.feature.authorization.rbac.file = classpath:rbac_rules.json
+spring.security.oauth2.resourceserver.jwt.issuer-uri= http://localhost:9096/realms/BaSyx
+```
+
+## RBAC rule configuration
+
+For configuring RBAC rules, all the rbac rules should be configured inside a json file, the rules are defined as below:
+
+```
+[
+  {
+    "role": "basyx-reader",
+    "action": "READ",
+    "targetInformation": {
+      "@type": "aas",
+      "aasId": "*"
+    }
+  },
+  {
+    "role": "admin",
+    "action": ["CREATE", "READ", "UPDATE", "DELETE"],
+    "targetInformation": {
+      "@type": "aas",
+      "aasId": "*"
+    }
+  },
+  {
+    "role": "basyx-deleter",
+    "action": "DELETE",
+    "targetInformation": {
+      "@type": "aas",
+      "aasId": "specificAasId"
+    }
+  }
+ ]
+```
+
+The role defines which role is allowed to perform the defined actions. The role is as per the configuration of identity providers or based on the organization. Action could be CREATE, READ, UPDATE, DELETE, and EXECUTE, there could be a single action or multiple actions as a list (cf. admin configuration above).
+
+The targetInformation defines coarse-grained control over the resource, you may define the aasId with a wildcard (\*), it means the defined role x with action y can access any Asset Administration Shell on the repository. You can also define a specific AAS Identifier in place of the wildcard (\*), then the role x with action y could be performed only on that particular AAS.
+
+Note: The Action are fixed as of now and limited to (CREATE, READ, UPDATE, DELETE, and EXECUTE) but later user configurable mapping of these actions would be provided.
+
+

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/pom.xml
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.digitaltwin.basyx</groupId>
+		<artifactId>basyx.aasregistry</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>basyx.aasregistry-feature-authorization</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-service</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-service-basemodel</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.http</artifactId>
+			<scope>test</scope>
+			<classifier>tests</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.http</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.authorization</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.authorization</artifactId>
+			<scope>test</scope>
+			<classifier>tests</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasrepository-http</artifactId>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AasTargetInformation.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AasTargetInformation.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetInformation;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetInformationSubtype;
+
+/**
+ * Specialization of {@link TargetInformation} for Aas target information
+ *
+ */
+@TargetInformationSubtype(getValue = "aas")
+public class AasTargetInformation implements TargetInformation {
+	
+	private String aasId;
+
+	@JsonCreator
+	public AasTargetInformation(final @JsonProperty("aasId") String aasId) {
+		this.aasId = aasId;
+	}
+
+	@Override
+	public Map<String, String> toMap() {
+		final Map<String, String> map = new HashMap<>();
+		map.put("aasId", aasId);
+		return map;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(aasId);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AasTargetInformation other = (AasTargetInformation) obj;
+		return Objects.equals(aasId, other.aasId);
+	}
+
+	@Override
+	public String toString() {
+		return "AasTargetInformation [aasId=" + aasId + "]";
+	}
+	
+	public String getAasId() {
+		return aasId;
+	}
+
+}

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AuthorizedAasRegistryConfiguration.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AuthorizedAasRegistryConfiguration.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization;
+
+import org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization.rbac.AasTargetPermissionVerifier;
+import org.eclipse.digitaltwin.basyx.authorization.CommonAuthorizationProperties;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacPermissionResolver;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacStorage;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RoleProvider;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.SimpleRbacPermissionResolver;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetPermissionVerifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for authorized {@link AuthorizedAasRegistryStorage}
+ * 
+ */
+@Configuration
+@ConditionalOnExpression("#{${" + CommonAuthorizationProperties.ENABLED_PROPERTY_KEY + ":false}}")
+public class AuthorizedAasRegistryConfiguration {
+	
+	@Bean
+	public TargetPermissionVerifier<AasTargetInformation> getAasTargetPermissionVerifier() {
+		return new AasTargetPermissionVerifier();
+	}
+	
+	@Bean
+	public RbacPermissionResolver<AasTargetInformation> getAasPermissionResolver(RbacStorage rbacStorage, RoleProvider roleProvider, TargetPermissionVerifier<AasTargetInformation> targetPermissionVerifier) {
+		return new SimpleRbacPermissionResolver<>(rbacStorage, roleProvider, targetPermissionVerifier);
+	}
+
+	@Bean
+	public AuthorizedAasRegistryFeature getAasStorageFeature(RbacPermissionResolver<AasTargetInformation> rbacPermissionResolver) {
+		return new AuthorizedAasRegistryFeature(rbacPermissionResolver);
+	}
+}

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AuthorizedAasRegistryFeature.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AuthorizedAasRegistryFeature.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization;
+
+import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStorage;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStorageFeature;
+import org.eclipse.digitaltwin.basyx.authorization.CommonAuthorizationProperties;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacPermissionResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Feature for authorized {@link AasRegistryStorage}
+ * 
+ */
+@Component
+@ConditionalOnExpression("#{${" + CommonAuthorizationProperties.ENABLED_PROPERTY_KEY + ":false}}")
+@Order(0)
+public class AuthorizedAasRegistryFeature implements AasRegistryStorageFeature {
+	
+	@Value("${" + CommonAuthorizationProperties.ENABLED_PROPERTY_KEY + ":}")
+	private boolean enabled;
+	
+	private RbacPermissionResolver<AasTargetInformation> permissionResolver;
+
+	@Autowired
+	public AuthorizedAasRegistryFeature(RbacPermissionResolver<AasTargetInformation> permissionResolver) {
+		this.permissionResolver = permissionResolver;
+	}
+
+	@Override
+	public AasRegistryStorage decorate(AasRegistryStorage storage) {
+		return new AuthorizedAasRegistryStorage(storage, permissionResolver);
+	}
+
+	@Override
+	public String getName() {
+		return "AasRegistry Authorization";
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return enabled;
+	}
+}

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AuthorizedAasRegistryStorage.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AuthorizedAasRegistryStorage.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization.rbac.AasTargetPermissionVerifier;
+import org.eclipse.digitaltwin.basyx.aasregistry.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.model.ShellDescriptorSearchRequest;
+import org.eclipse.digitaltwin.basyx.aasregistry.model.ShellDescriptorSearchResponse;
+import org.eclipse.digitaltwin.basyx.aasregistry.model.SubmodelDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.errors.AasDescriptorAlreadyExistsException;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.errors.AasDescriptorNotFoundException;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.errors.SubmodelAlreadyExistsException;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.errors.SubmodelNotFoundException;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStorage;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.DescriptorFilter;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.Action;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacPermissionResolver;
+import org.eclipse.digitaltwin.basyx.core.exceptions.InsufficientPermissionException;
+import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
+import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
+
+/**
+ * Decorator for authorized {@link AasRegistryStorage}
+ *
+ *
+ */
+public class AuthorizedAasRegistryStorage implements AasRegistryStorage {
+
+	private AasRegistryStorage decorated;
+	private RbacPermissionResolver<AasTargetInformation> permissionResolver;
+	
+	public AuthorizedAasRegistryStorage(AasRegistryStorage decorated, RbacPermissionResolver<AasTargetInformation> permissionResolver) {
+		this.decorated = decorated;
+		this.permissionResolver = permissionResolver;
+	}
+
+	@Override
+	public CursorResult<List<AssetAdministrationShellDescriptor>> getAllAasDescriptors(PaginationInfo pRequest, DescriptorFilter filter) {
+		assertHasPermission(Action.READ, AasTargetPermissionVerifier.ALL_ALLOWED_WILDCARD);
+		return decorated.getAllAasDescriptors(pRequest, filter);
+	}
+
+	@Override
+	public AssetAdministrationShellDescriptor getAasDescriptor(String aasDescriptorId) throws AasDescriptorNotFoundException {
+		assertHasPermission(Action.READ, aasDescriptorId);
+		return decorated.getAasDescriptor(aasDescriptorId);
+	}
+
+	@Override
+	public void insertAasDescriptor(AssetAdministrationShellDescriptor descr) throws AasDescriptorAlreadyExistsException {
+		assertHasPermission(Action.CREATE, descr.getId());
+		decorated.insertAasDescriptor(descr);
+	}
+
+	@Override
+	public void replaceAasDescriptor(String aasDescriptorId, AssetAdministrationShellDescriptor descriptor) throws AasDescriptorNotFoundException {
+		assertHasPermission(Action.UPDATE, aasDescriptorId);
+		String newId = descriptor.getId();
+		if (aasDescriptorId != newId) {
+			assertHasPermission(Action.CREATE, newId);
+		}
+		decorated.replaceAasDescriptor(aasDescriptorId, descriptor);
+	}
+
+	@Override
+	public void removeAasDescriptor(String aasDescriptorId) throws AasDescriptorNotFoundException {
+		assertHasPermission(Action.DELETE, aasDescriptorId);
+		decorated.removeAasDescriptor(aasDescriptorId);
+	}
+
+	@Override
+	public CursorResult<List<SubmodelDescriptor>> getAllSubmodels(String aasDescriptorId, PaginationInfo pRequest) throws AasDescriptorNotFoundException {
+		assertHasPermission(Action.READ, aasDescriptorId);
+		return decorated.getAllSubmodels(aasDescriptorId, pRequest);
+	}
+
+	@Override
+	public SubmodelDescriptor getSubmodel(String aasDescriptorId, String submodelId) throws AasDescriptorNotFoundException, SubmodelNotFoundException {
+		assertHasPermission(Action.READ, aasDescriptorId);
+		return decorated.getSubmodel(aasDescriptorId, submodelId);
+	}
+
+	@Override
+	public void insertSubmodel(String aasDescriptorId, SubmodelDescriptor submodel) throws AasDescriptorNotFoundException, SubmodelAlreadyExistsException {
+		assertHasPermission(Action.UPDATE, aasDescriptorId);		
+		decorated.insertSubmodel(aasDescriptorId, submodel);
+	}
+
+	@Override
+	public void replaceSubmodel(String aasDescriptorId, String submodelId, SubmodelDescriptor submodel) throws AasDescriptorNotFoundException, SubmodelNotFoundException {
+		assertHasPermission(Action.UPDATE, aasDescriptorId);
+		decorated.replaceSubmodel(aasDescriptorId, submodelId, submodel);
+	}
+
+	@Override
+	public void removeSubmodel(String aasDescriptorId, String submodelId) throws AasDescriptorNotFoundException, SubmodelNotFoundException {
+		assertHasPermission(Action.UPDATE, aasDescriptorId);
+		decorated.removeSubmodel(aasDescriptorId, submodelId);
+	}
+
+	@Override
+	public Set<String> clear() {
+		assertHasPermission(Action.DELETE, AasTargetPermissionVerifier.ALL_ALLOWED_WILDCARD);
+		return decorated.clear();
+	}
+
+	@Override
+	public ShellDescriptorSearchResponse searchAasDescriptors(ShellDescriptorSearchRequest request) {
+		assertHasPermission(Action.READ, AasTargetPermissionVerifier.ALL_ALLOWED_WILDCARD);
+		return decorated.searchAasDescriptors(request);
+	}
+	
+	private void assertHasPermission(Action action, String aasId) {
+		boolean isAuthorized = permissionResolver.hasPermission(action, new AasTargetInformation(aasId));
+		throwExceptionIfInsufficientPermission(isAuthorized);
+	}
+	
+	private void throwExceptionIfInsufficientPermission(boolean isAuthorized) {
+		if (!isAuthorized)
+			throw new InsufficientPermissionException("Insufficient Permission: The current subject does not have the required permissions for this operation.");
+	}
+}

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/rbac/AasTargetPermissionVerifier.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/rbac/AasTargetPermissionVerifier.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (C) 2023 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization.rbac;
+
+import org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization.AasTargetInformation;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacRule;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetPermissionVerifier;
+
+/**
+ * Verifies the {@link AasTargetInformation} against the {@link RbacRule}
+ * 
+ */
+public class AasTargetPermissionVerifier implements TargetPermissionVerifier<AasTargetInformation> {
+
+	public static final String ALL_ALLOWED_WILDCARD = "*";
+	
+	@Override
+	public boolean isVerified(RbacRule rbacRule, AasTargetInformation targetInformation) {
+		String shellId = targetInformation.getAasId();
+		
+		AasTargetInformation rbacRuleAasTargetInformation = (AasTargetInformation) rbacRule.getTargetInformation();
+		
+		return rbacRuleAasTargetInformation.getAasId().equals(ALL_ALLOWED_WILDCARD) || rbacRuleAasTargetInformation.getAasId().equals(shellId);
+	}
+
+}

--- a/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/InMemoryAasStorageConfiguration.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/InMemoryAasStorageConfiguration.java
@@ -24,7 +24,10 @@
  ******************************************************************************/
 package org.eclipse.digitaltwin.basyx.aasregistry.service.configuration;
 
+import java.util.List;
+
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStorage;
+import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStorageFeature;
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.CursorEncodingRegistryStorage;
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.memory.InMemoryAasRegistryStorage;
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.memory.ThreadSafeAasRegistryStorageDecorator;
@@ -32,13 +35,27 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import lombok.extern.log4j.Log4j2;
+
 @Configuration
+@Log4j2
 public class InMemoryAasStorageConfiguration {
 
+	
+	
 	@Bean
 	@ConditionalOnProperty(prefix = "registry", name = "type", havingValue = "inMemory")
-	public AasRegistryStorage storage() {
-		return new ThreadSafeAasRegistryStorageDecorator(new CursorEncodingRegistryStorage(new InMemoryAasRegistryStorage()));
+	public AasRegistryStorage storage(List<AasRegistryStorageFeature> features) {
+		log.info("Creating in-memory storage");
+		AasRegistryStorage storage = new ThreadSafeAasRegistryStorageDecorator(new CursorEncodingRegistryStorage(new InMemoryAasRegistryStorage()));
+		return applyFeatures(storage, features);
 	}
 
+	private AasRegistryStorage applyFeatures(AasRegistryStorage storage, List<AasRegistryStorageFeature> features) {
+		for (AasRegistryStorageFeature eachFeature : features) {
+			log.info("Activating feature " + eachFeature.getName());
+			storage = eachFeature.decorate(storage);
+		}
+		return storage;
+	}
 }

--- a/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/InMemoryAasRegistyStorageTest.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/InMemoryAasRegistyStorageTest.java
@@ -47,7 +47,7 @@ public class InMemoryAasRegistyStorageTest extends AasRegistryStorageTest {
 	public AasRegistryStorage createCloningInMemoryStorage() {
 		// we save the initial storage state in some testcases
 		// so we do not want to alter the object and thus need a deep copy
-		return new CloningAasRegistryStorageDecorator(new InMemoryAasStorageConfiguration().storage());
+		return new CloningAasRegistryStorageDecorator(new InMemoryAasStorageConfiguration().storage(List.of()));
 	}
 	
 	

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/pom.xml
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/pom.xml
@@ -7,7 +7,6 @@
 		<groupId>org.eclipse.digitaltwin.basyx</groupId>
 		<artifactId>basyx.aasregistry</artifactId>
 		<version>${revision}</version>
-
 	</parent>
 
 	<artifactId>basyx.aasregistry-service-release-kafka-mem</artifactId>
@@ -17,11 +16,23 @@
 		<start-class>org.eclipse.digitaltwin.basyx.aasregistry.service.OpenApiGeneratorApplication</start-class>
 		<docker.image.name>aas-registry-kafka-mem</docker.image.name>
 	</properties>
-	<dependencies>
+	<dependencies>		
+	<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-feature-authorization</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.authorization</artifactId>
+		</dependency>
 		<dependency>
 			<!-- it was just marked as provided so we need to redefine it here -->
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.aasregistry-service-basemodel</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-feature-authorization</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/pom.xml
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/pom.xml
@@ -16,11 +16,23 @@
 		<docker.image.name>aas-registry-kafka-mongodb</docker.image.name>
 	</properties>
 
-	<dependencies>
+	<dependencies>		
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-feature-authorization</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.authorization</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.aasregistry-service-mongodb-storage</artifactId>
 		</dependency>	
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-feature-authorization</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/pom.xml
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/pom.xml
@@ -10,7 +10,7 @@
 
 	</parent>
 	
-	<artifactId>basyx.aasregistry-service-release-log-mem</artifactId>
+	<artifactId>basyx.aasegistry-service-release-log-mem</artifactId>
 	
 	<properties>
 		<spring-cloud.version>2020.0.4</spring-cloud.version>
@@ -18,6 +18,14 @@
 		<docker.image.name>aas-registry-log-mem</docker.image.name>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-feature-authorization</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.authorization</artifactId>
+		</dependency>
 		<dependency>
 		<!-- it was just marked as provided so we need to redefine it here -->
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/pom.xml
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/pom.xml
@@ -20,6 +20,14 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.authorization</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.aasregistry-feature-authorization</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.aasregistry-service-mongodb-storage</artifactId>
 		</dependency>
 		<dependency>

--- a/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/AasRegistryStorageFeature.java
+++ b/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/AasRegistryStorageFeature.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (C) 2023 DFKI GmbH (https://www.dfki.de/en/web)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.digitaltwin.basyx.aasregistry.service.storage;
+
+public interface AasRegistryStorageFeature {
+
+	AasRegistryStorage decorate(AasRegistryStorage aasRegistryStorage);
+
+	boolean isEnabled();
+
+	String getName();
+
+}

--- a/basyx.aasregistry/basyx.aasregistry-service/templates/openapi2SpringBoot.mustache
+++ b/basyx.aasregistry/basyx.aasregistry-service/templates/openapi2SpringBoot.mustache
@@ -1,0 +1,34 @@
+package {{basePackage}};
+
+{{#openApiNullable}}
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+{{/openApiNullable}}
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+
+@SpringBootApplication(
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
+)
+@ComponentScan(
+    basePackages = {"org.eclipse.digitaltwin.basyx.authorization", "org.eclipse.digitaltwin.basyx.authorization.rbac", "org.eclipse.digitaltwin.basyx.aasregistry.feature", "{{basePackage}}", "{{apiPackage}}" , "{{configPackage}}"},
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class
+)
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+{{#openApiNullable}}
+    @Bean(name = "{{basePackage}}.OpenApiGeneratorApplication.jsonNullableModule")
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+{{/openApiNullable}}
+
+}

--- a/basyx.aasregistry/pom.xml
+++ b/basyx.aasregistry/pom.xml
@@ -35,6 +35,7 @@
 		<jsr305.version>3.0.2</jsr305.version>
 		<jsonpatch.plugin.version>0.5.0</jsonpatch.plugin.version>
 		<patch.base-extensions.name>patch-base-extensions.yaml</patch.base-extensions.name>
+		<docker.context.dir>${project.basedir}/src/main/docker</docker.context.dir>
 	</properties>
 
 	<modules>
@@ -51,6 +52,7 @@
 		<module>basyx.aasregistry-service-release-log-mongodb</module>
 		<module>basyx.aasregistry-service-release-kafka-mem</module>
 		<module>basyx.aasregistry-service-release-kafka-mongodb</module>
+		<module>basyx.aasregistry-feature-authorization</module>
 
 	</modules>
 
@@ -148,6 +150,11 @@
 			<dependency>
 				<groupId>org.eclipse.digitaltwin.basyx</groupId>
 				<artifactId>basyx.aasregistry-service-inmemory-storage</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.digitaltwin.basyx</groupId>
+				<artifactId>basyx.aasregistry-feature-authorization</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -279,6 +286,8 @@
 					<plugin>
 						<groupId>io.fabric8</groupId>
 						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.43.3</version>
+						<inherited>false</inherited>
 						<configuration>
 							<images>
 								<image>


### PR DESCRIPTION
Additional steps to do:

- fix objectmapper problems (can't read configuration rules: functional-property "Action" into List)
  - we need to update the bean settings 
- check if all beans are loaded -> use the [mustache template](https://github.com/eclipse-basyx/basyx-java-server-sdk/compare/main...geso02:basyx-java-server-sdk:main#diff-8a2a055d2808e0a5db7c797d91581f45deb70bc93e3376d60c0a9e77a8e46035) to add additional basePackages for scanning
- move shared classes for aas-repo and registry to a common-project (currently duplicate classes)
- write unit tests
- perform same tasks for sm-registry