### PR TITLE
Removes mandatory inclusion of Submodel IDs during serialization

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/TestAASEnvironmentSerialization.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/TestAASEnvironmentSerialization.java
@@ -99,9 +99,11 @@ public class TestAASEnvironmentSerialization {
 	@Test
 	public void testAASEnviromentSerializationWithJSON() throws SerializationException, IOException, DeserializationException {
 		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		String jsonSerialization = aasEnvironment.createJSONAASEnvironmentSerialization(getShellIds(createDummyShells()), getSubmodelIds(createDummySubmodels()), includeConceptDescription);
-		validateJSON(jsonSerialization, includeConceptDescription);
+		validateJSON(jsonSerialization, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 
 		validateRepositoriesState();
 	}
@@ -109,9 +111,11 @@ public class TestAASEnvironmentSerialization {
 	@Test
 	public void testAASEnviromentSerializationWithXML() throws SerializationException, IOException, SAXException, DeserializationException {
 		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		String xmlSerialization = aasEnvironment.createXMLAASEnvironmentSerialization(getShellIds(createDummyShells()), getSubmodelIds(createDummySubmodels()), includeConceptDescription);
-		validateXml(xmlSerialization, includeConceptDescription);
+		validateXml(xmlSerialization, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 
 		validateRepositoriesState();
 	}
@@ -119,9 +123,11 @@ public class TestAASEnvironmentSerialization {
 	@Test
 	public void testAASEnviromentSerializationWithAASX() throws SerializationException, IOException, InvalidOperationException, InvalidFormatException, DeserializationException {
 		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		byte[] serialization = aasEnvironment.createAASXAASEnvironmentSerialization(getShellIds(createDummyShells()), getSubmodelIds(createDummySubmodels()), includeConceptDescription);
-		checkAASX(new ByteArrayInputStream(serialization), includeConceptDescription);
+		checkAASX(new ByteArrayInputStream(serialization), aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 
 		validateRepositoriesState();
 	}
@@ -129,31 +135,33 @@ public class TestAASEnvironmentSerialization {
 	@Test
 	public void testAASEnviromentSerializationWithJSONExcludeCD() throws SerializationException, IOException, DeserializationException {
 		boolean includeConceptDescription = false;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		String jsonSerialization = aasEnvironment.createJSONAASEnvironmentSerialization(getShellIds(createDummyShells()), getSubmodelIds(createDummySubmodels()), includeConceptDescription);
-		validateJSON(jsonSerialization, includeConceptDescription);
+		validateJSON(jsonSerialization, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 
 		validateRepositoriesState();
 	}
 
-	public static void validateJSON(String actual, boolean includeConceptDescription) throws DeserializationException {
+	public static void validateJSON(String actual, boolean areAASsIncluded, boolean areSubmodelsIncluded, boolean includeConceptDescription) throws DeserializationException {
 		JsonDeserializer jsonDeserializer = new JsonDeserializer();
 		Environment aasEnvironment = jsonDeserializer.read(actual, Environment.class);
-		checkAASEnvironment(aasEnvironment, includeConceptDescription);
+		checkAASEnvironment(aasEnvironment, areAASsIncluded, areSubmodelsIncluded, includeConceptDescription);
 	}
 
-	public static void validateXml(String actual, boolean includeConceptDescription) throws DeserializationException {
+	public static void validateXml(String actual, boolean areAASsIncluded, boolean areSubmodelsIncluded, boolean includeConceptDescription) throws DeserializationException {
 		XmlDeserializer xmlDeserializer = new XmlDeserializer();
 		Environment aasEnvironment = xmlDeserializer.read(actual);
 
-		checkAASEnvironment(aasEnvironment, includeConceptDescription);
+		checkAASEnvironment(aasEnvironment, areAASsIncluded, areSubmodelsIncluded, includeConceptDescription);
 	}
 
-	public static void checkAASX(InputStream inputStream, boolean includeConceptDescription) throws IOException, InvalidFormatException, DeserializationException {
+	public static void checkAASX(InputStream inputStream, boolean areAASsIncluded, boolean areSubmodelsIncluded, boolean includeConceptDescription) throws IOException, InvalidFormatException, DeserializationException {
 		AASXDeserializer aasxDeserializer = new AASXDeserializer(inputStream);
 		Environment environment = aasxDeserializer.read();
 
-		checkAASEnvironment(environment, includeConceptDescription);
+		checkAASEnvironment(environment, areAASsIncluded, areSubmodelsIncluded, includeConceptDescription);
 		inputStream.close();
 	}
 
@@ -167,14 +175,15 @@ public class TestAASEnvironmentSerialization {
 		return conceptDescriptions;
 	}
 
-	private static void checkAASEnvironment(Environment aasEnvironment, boolean areConceptDescriptionsIncluded) {
-		assertAasIds(aasEnvironment);
+	private static void checkAASEnvironment(Environment aasEnvironment, boolean areAASsIncluded, boolean areSubmodelsIncluded, boolean areConceptDescriptionsIncluded) {
+		if (areAASsIncluded)
+			assertAasIds(aasEnvironment);
 
-		assertSubmodelIds(aasEnvironment);
+		if (areSubmodelsIncluded)
+			assertSubmodelIds(aasEnvironment);
 
-		if (areConceptDescriptionsIncluded) {
+		if (areConceptDescriptionsIncluded)
 			assertConceptDescriptionIds(aasEnvironment);
-		}
 	}
 
 	private static void assertConceptDescriptionIds(Environment aasEnvironment) {

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AasEnvironmentApiHTTPController.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AasEnvironmentApiHTTPController.java
@@ -121,16 +121,25 @@ public class AasEnvironmentApiHTTPController implements AASEnvironmentHTTPApi {
 
 	private List<String> getOriginalIds(List<String> ids) {
 		List<String> results = new ArrayList<>();
+		
+		if (!areValidIds(ids))
+			return results;
+		
 		ids.forEach(id -> {
 			results.add(Base64UrlEncodedIdentifier.fromEncodedValue(id).getIdentifier());
 		});
+		
 		return results;
 	}
 
 	private boolean areParametersValid(String accept, @Valid List<String> aasIds, @Valid List<String> submodelIds) {
-		if (aasIds.isEmpty() || submodelIds.isEmpty()) {
+		if (!areValidIds(aasIds) && !areValidIds(submodelIds))
 			return false;
-		}
+		
 		return (accept.equals(ACCEPT_AASX) || accept.equals(ACCEPT_JSON) || accept.equals(ACCEPT_XML));
+	}
+
+	private boolean areValidIds(List<String> identifiers) {
+		return identifiers != null && !identifiers.isEmpty();
 	}
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP.java
@@ -96,41 +96,73 @@ public class TestAasEnvironmentHTTP {
 	@Test
 	public void testAASEnvironmentSertializationWithJSON() throws IOException, ParseException, DeserializationException {
 		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		CloseableHttpResponse response = executeGetOnURL(createSerializationURL(includeConceptDescription), JSON_MIMETYPE);
 		String actual = BaSyxHttpTestUtils.getResponseAsString(response);
-		TestAASEnvironmentSerialization.validateJSON(actual, includeConceptDescription);
+		TestAASEnvironmentSerialization.validateJSON(actual, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 	}
 
 	@Test
 	public void testAASEnvironmentSertializationWithXML() throws IOException, ParseException, DeserializationException {
 		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		CloseableHttpResponse response = executeGetOnURL(createSerializationURL(includeConceptDescription), XML_MIMETYPE);
 		String actual = BaSyxHttpTestUtils.getResponseAsString(response);
-		TestAASEnvironmentSerialization.validateXml(actual, includeConceptDescription);
+		TestAASEnvironmentSerialization.validateXml(actual, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 	}
 
 	@Test
 	public void testAASEnvironmentSertializationWithAASX() throws IOException, ParseException, DeserializationException, InvalidFormatException {
 		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		CloseableHttpResponse response = executeGetOnURL(createSerializationURL(includeConceptDescription), AASX_MIMETYPE);
 		assertEquals(HttpStatus.OK.value(), response.getCode());
 
-		TestAASEnvironmentSerialization.checkAASX(response.getEntity()
-				.getContent(), includeConceptDescription);
+		TestAASEnvironmentSerialization.checkAASX(response.getEntity().getContent(), aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 	}
 
 	@Test
 	public void testAASEnvironmentSertializationWithAASXExcludeCD() throws IOException, ParseException, DeserializationException, InvalidFormatException {
 		boolean includeConceptDescription = false;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = true;
 
 		CloseableHttpResponse response = executeGetOnURL(createSerializationURL(includeConceptDescription), AASX_MIMETYPE);
 		assertEquals(HttpStatus.OK.value(), response.getCode());
 
-		TestAASEnvironmentSerialization.checkAASX(response.getEntity()
-				.getContent(), includeConceptDescription);
+		TestAASEnvironmentSerialization.checkAASX(response.getEntity().getContent(), aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
+	}
+	
+	@Test
+	public void aasEnvironmentSertializationOnlyAasIds() throws IOException, ParseException, DeserializationException {
+		boolean includeConceptDescription = false;
+		boolean aasIdsIncluded = true;
+		boolean submodelIdsIncluded = false;
+
+		CloseableHttpResponse response = executeGetOnURL(getSerializationURLOnlyAas(createIdCollection(DummyAASEnvironmentComponent.AAS_TECHNICAL_DATA_ID, DummyAASEnvironmentComponent.AAS_OPERATIONAL_DATA_ID), includeConceptDescription), JSON_MIMETYPE);
+		assertEquals(HttpStatus.OK.value(), response.getCode());
+		
+		String actual = BaSyxHttpTestUtils.getResponseAsString(response);
+		TestAASEnvironmentSerialization.validateJSON(actual, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
+	}
+	
+	@Test
+	public void aasEnvironmentSertializationOnlySubmodelIds() throws IOException, ParseException, DeserializationException {
+		boolean includeConceptDescription = true;
+		boolean aasIdsIncluded = false;
+		boolean submodelIdsIncluded = true;
+
+		CloseableHttpResponse response = executeGetOnURL(getSerializationURLOnlySubmodels(createIdCollection(DummyAASEnvironmentComponent.SUBMODEL_OPERATIONAL_DATA_ID, DummyAASEnvironmentComponent.SUBMODEL_TECHNICAL_DATA_ID), includeConceptDescription), JSON_MIMETYPE);
+		assertEquals(HttpStatus.OK.value(), response.getCode());
+		
+		String actual = BaSyxHttpTestUtils.getResponseAsString(response);
+		TestAASEnvironmentSerialization.validateJSON(actual, aasIdsIncluded, submodelIdsIncluded, includeConceptDescription);
 	}
 
 	@Test
@@ -237,7 +269,27 @@ public class TestAasEnvironmentHTTP {
 		String aasIdsArrayString = createIdsArrayString(aasIds);
 		String submodelIdsArrayString = createIdsArrayString(submodelIds);
 
-		return getURL() + "/serialization?aasIds=" + aasIdsArrayString + "&submodelIds=" + submodelIdsArrayString + "&includeConceptDescriptions=" + includeConceptDescription;
+		return getURL() + "/serialization?" + getAasIdsParameter(aasIdsArrayString) + "&" + getSubmodelIdsParameter(submodelIdsArrayString) + "&includeConceptDescriptions=" + includeConceptDescription;
+	}
+	
+	private static String getSerializationURLOnlyAas(Collection<String> aasIds, boolean includeConceptDescription) {
+		String aasIdsArrayString = createIdsArrayString(aasIds);
+
+		return getURL() + "/serialization?" + getAasIdsParameter(aasIdsArrayString) + "&includeConceptDescriptions=" + includeConceptDescription;
+	}
+	
+	private static String getSerializationURLOnlySubmodels(Collection<String> submodelIds, boolean includeConceptDescription) {
+		String submodelIdsArrayString = createIdsArrayString(submodelIds);
+		
+		return getURL() + "/serialization?" + getSubmodelIdsParameter(submodelIdsArrayString) + "&includeConceptDescriptions=" + includeConceptDescription;
+	}
+	
+	private static String getAasIdsParameter(String aasIdsArrayString) {
+		return "aasIds=" + aasIdsArrayString;
+	}
+	
+	private static String getSubmodelIdsParameter(String submodelIdsArrayString) {
+		return "submodelIds=" + submodelIdsArrayString;
 	}
 
 	private static String createIdsArrayString(Collection<String> ids) {


### PR DESCRIPTION
- The AAS Environment's serialization endpoint enforces the aasIds as well as submodelIds as request parameters. This shouldn't be the case nor should it be enforced. Instead, only one of them is fine.
- Removes this mandatory inclusion in this PR.

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>