### PR TITLE
Fixes wrong Descriptors endpoint when reg-int is enabled

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/AasDescriptorFactory.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/AasDescriptorFactory.java
@@ -49,7 +49,7 @@ import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifier;
 public class AasDescriptorFactory {
 
 	private static final String AAS_INTERFACE = "AAS-3.0";
-	private static final String AAS_REPOSITORY_PATH = "/shells";
+	private static final String AAS_REPOSITORY_PATH = "shells";
 	
 	private AssetAdministrationShell shell;
 	private String aasRepositoryURL;

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/SubmodelDescriptorFactory.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/SubmodelDescriptorFactory.java
@@ -49,7 +49,7 @@ import org.eclipse.digitaltwin.basyx.submodelrepository.feature.registry.integra
 public class SubmodelDescriptorFactory {
 
 	private static final String SUBMODEL_INTERFACE = "SUBMODEL-3.0";
-	private static final String SUBMODEL_REPOSITORY_PATH = "/submodels";
+	private static final String SUBMODEL_REPOSITORY_PATH = "submodels";
 
 	private Submodel submodel;
 	private String submodelRepositoryURL;


### PR DESCRIPTION
With the registry integration feature enabled, if the basyx.externalurl is set with some base-path or context-path then the endpoint inside descriptors is ignoring the base-path or context-path.

For example:
basyx.externalurl = http://localhost/aas-env

Then the endpoint for AAS Descriptor should be:
http://localhost/aas-env/shells/MDNhODA4OGItNzQzZi00ZTRkLWJkNmMtZDZmNGU3MDE3MTlm

But instead it was:
http://localhost/shells/MDNhODA4OGItNzQzZi00ZTRkLWJkNmMtZDZmNGU3MDE3MTlm

**This PR fixes this issue.**

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>