### PR TITLE
Fixes reuploading AASX does not work even after complete deletion

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -82,12 +82,13 @@ public class DefaultAASEnvironment implements AasEnvironment {
 	private XmlSerializer xmlSerializer = new XmlSerializer();
 	private AASXSerializer aasxSerializer = new AASXSerializer();
 	private MetamodelCloneCreator cloneCreator = new MetamodelCloneCreator();
-	private IdentifiableAssertion checker = new IdentifiableAssertion();
-
+	private IdentifiableAssertion checker;
+	
 	public DefaultAASEnvironment(AasRepository aasRepository, SubmodelRepository submodelRepository, ConceptDescriptionRepository conceptDescriptionRepository) {
 		this.aasRepository = aasRepository;
 		this.submodelRepository = submodelRepository;
 		this.conceptDescriptionRepository = conceptDescriptionRepository;
+		this.checker = new IdentifiableAssertion(aasRepository, submodelRepository);
 	}
 
 	@Override

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/environmentloader/IdentifiableAssertion.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/environmentloader/IdentifiableAssertion.java
@@ -27,36 +27,62 @@ package org.eclipse.digitaltwin.basyx.aasenvironment.environmentloader;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.Identifiable;
+import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
 import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingIdentifierException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.submodelrepository.SubmodelRepository;
 
 /**
  * Assertion to ensure that no duplicates ids are loaded from file
  *
- * @author Gerhard Sonnenberg DFKI GmbH
+ * @author Gerhard Sonnenberg DFKI GmbH, danish
  *
  */
 public class IdentifiableAssertion {
 
+	private AasRepository aasRepo;
+	private SubmodelRepository smRepo;
 	private final Set<String> currentShellIds = new HashSet<>();
 	private final Set<String> currentSubmodelIds = new HashSet<>();
 
-	public void assertNoDuplicateIds(Environment environment) {
-		assertNoDuplicateIds(environment.getAssetAdministrationShells(), currentShellIds);
-		assertNoDuplicateIds(environment.getSubmodels(), currentSubmodelIds);
+	public IdentifiableAssertion(AasRepository aasRepo, SubmodelRepository smRepo) {
+		this.aasRepo = aasRepo;
+		this.smRepo = smRepo;
 	}
-	
-	private <T extends Identifiable> void assertNoDuplicateIds(List<T> identifiables, Set<String> currentIds) throws CollidingIdentifierException {
+
+	public void assertNoDuplicateIds(Environment environment) {
+		assertNoDuplicateIds(environment.getAssetAdministrationShells(), currentShellIds, id -> {
+		    aasRepo.getAas(id);
+		    return null;
+		});
+		assertNoDuplicateIds(environment.getSubmodels(), currentSubmodelIds, id -> {
+		    smRepo.getSubmodel(id);
+		    return null;
+		});
+	}
+
+	private <T extends Identifiable> void assertNoDuplicateIds(List<T> identifiables, Set<String> currentIds,
+			Function<String, Void> retrieveElementFunction) throws CollidingIdentifierException {
+
 		if (identifiables == null) {
 			return;
 		}
+
 		for (T eachIdentifiable : identifiables) {
 			String id = eachIdentifiable.getId();
 			boolean success = currentIds.add(id);
 			if (!success) {
-				throw new CollidingIdentifierException(id);
+				try {
+					retrieveElementFunction.apply(id);
+					
+					throw new CollidingIdentifierException(id);
+				} catch (ElementDoesNotExistException e) {
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When uploading a AASX file and then deleting all submodels / AASs that are contained in the file, BaSyx returns a 409 Conflict error when reuploading the AASX file.

See: #269 

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>