### PR TITLE
Building Containers locally fails due to connectivity error

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository.component/src/main/resources/application-integration.properties
+++ b/basyx.aasrepository/basyx.aasrepository.component/src/main/resources/application-integration.properties
@@ -6,7 +6,7 @@ basyx.aasrepo.name=aas-repo
 
 basyx.backend = InMemory
 
-basyx.aasrepository.feature.registryintegration=http://localhost:8050
+basyx.aasrepository.feature.registryintegration=http://aas-registry-log-mem:8080
 basyx.externalurl=http://localhost:8081
 
 #basyx.backend = MongoDB

--- a/basyx.submodelrepository/basyx.submodelrepository.component/src/main/resources/application-integration.properties
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/src/main/resources/application-integration.properties
@@ -6,7 +6,7 @@ basyx.smrepo.name = sm-repo
 
 basyx.backend = InMemory
 
-basyx.submodelrepository.feature.registryintegration=http://localhost:8060
+basyx.submodelrepository.feature.registryintegration=http://sm-registry-log-mem:8080
 basyx.externalurl=http://localhost:8081
 
 #basyx.backend = MongoDB

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
 								</build>
 								<run>
 									<network>
-										<mode>host</mode>
+										<mode>bridge</mode>
 									</network>
 								</run>
 							</image>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,8 @@
 								</build>
 								<run>
 									<network>
-										<mode>bridge</mode>
+									   <mode>custom</mode>
+									   <name>basyx-java-server-sdk</name>
 									</network>
 								</run>
 							</image>


### PR DESCRIPTION
The build process of the containers executes the integration tests. Currently, the tests fail locally due to connectivity issues. Somehow, the containers are not starting with the ports being published.
