### PR TITLE
Ignore unnecessary paths in Maven CI workflow

### DIFF
--- a/.github/workflows/maven_run_test.yml
+++ b/.github/workflows/maven_run_test.yml
@@ -6,6 +6,10 @@ name: Java CI with Maven
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - 'README.md'
 
 jobs:
   build:
@@ -25,4 +29,3 @@ jobs:
       - name: Stop environment
         if: always()
         run: docker  compose --project-directory ./ci down
-     

--- a/.github/workflows/maven_run_test.yml
+++ b/.github/workflows/maven_run_test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [ main ]
     paths-ignore:
+      - '.github/**'
       - 'docs/**'
       - 'examples/**'
       - 'README.md'


### PR DESCRIPTION
Changes in the ".github", "examples" and "docs" directories of the basyx-java-server-sdk should not trigger the CI.