### PR TITLE
Fix: AasService Thumbnail Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In addition, the following Clients are available:
 * [Submodel Service Client](basyx.submodelservice/basyx.submodelservice-client)
 
 ## Documentation, Roadmap & Examples
-In addition to the [general documentation](https://github.com/eclipse-basyx/basyx-java-server-sdk/tree/main/docs), each component has its own specific documentation that can be found in the respective folders. 
+In addition to the [general documentation](https://github.com/eclipse-basyx/basyx-java-server-sdk/tree/main/docs), each component has its own specific documentation that can be found in the respective folders. Additionally, we provide a general documentation on [readthedocs](https://wiki.basyx.org/en/latest/).
 Furthermore, we are providing easy to use [examples](examples) that can be leveraged for setting up your own AAS infrastructure.
 The future roadmap of BaSyx is described [here](https://github.com/eclipse-basyx/basyx-java-server-sdk/blob/main/docs/Roadmap.md).
 

--- a/basyx.aasservice/basyx.aasservice-backend-inmemory/pom.xml
+++ b/basyx.aasservice/basyx.aasservice-backend-inmemory/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/basyx.aasservice/basyx.aasservice-core/pom.xml
+++ b/basyx.aasservice/basyx.aasservice-core/pom.xml
@@ -30,10 +30,5 @@
 			<artifactId>commons-io</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/basyx.aasservice/basyx.aasservice-core/pom.xml
+++ b/basyx.aasservice/basyx.aasservice-core/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -17,7 +17,10 @@
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.core</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.eclipse.digitaltwin.basyx</groupId>
+			<artifactId>basyx.filerepository-backend-inmemory</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.aas4j</groupId>
 			<artifactId>aas4j-model</artifactId>
@@ -25,6 +28,11 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/basyx.aasservice/basyx.aasservice-core/src/test/java/org/eclipse/digitaltwin/basyx/aasservice/AasServiceSuite.java
+++ b/basyx.aasservice/basyx.aasservice-core/src/test/java/org/eclipse/digitaltwin/basyx/aasservice/AasServiceSuite.java
@@ -185,7 +185,6 @@ public abstract class AasServiceSuite {
 		);
 
 		InputStream actualThumbnailIs = new FileInputStream(aasServiceWithThumbnail.getThumbnail());
-
 		InputStream expectedThumbnail = createDummyImageIS_B();
 
 		assertTrue(IOUtils.contentEquals(expectedThumbnail, actualThumbnailIs));

--- a/basyx.aasservice/pom.xml
+++ b/basyx.aasservice/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>


### PR DESCRIPTION
The PR Corresponds to the task titled: "Improve testing of Thumbnail CRUD operations in the AasService"

It contains a fix for the following issues:

1. The getThumbnailTest should not first set the thumbnail; the suite should be the one to provide an AAS with a thumbnail already set
2. Similarly with updateThumbnail and deleteThumbnail
3. deleteThumbnail should use fail pattern instead of a global test except.