### PR TITLE
Modifies Registries TargetInformation to accept List of Ids

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AasRegistryTargetInformation.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/AasRegistryTargetInformation.java
@@ -27,6 +27,7 @@ package org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -42,23 +43,23 @@ import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetInformationSubtype
 @TargetInformationSubtype(getValue = "aas-registry")
 public class AasRegistryTargetInformation implements TargetInformation {
 	
-	private String aasId;
+	private List<String> aasIds;
 
 	@JsonCreator
-	public AasRegistryTargetInformation(final @JsonProperty("aasId") String aasId) {
-		this.aasId = aasId;
+	public AasRegistryTargetInformation(final @JsonProperty("aasIds") List<String> aasIds) {
+		this.aasIds = aasIds;
 	}
 
 	@Override
 	public Map<String, Object> toMap() {
 		final Map<String, Object> map = new HashMap<>();
-		map.put("aasId", aasId);
+		map.put("aasIds", aasIds);
 		return map;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(aasId);
+		return Objects.hash(aasIds);
 	}
 
 	@Override
@@ -70,16 +71,16 @@ public class AasRegistryTargetInformation implements TargetInformation {
 		if (getClass() != obj.getClass())
 			return false;
 		AasRegistryTargetInformation other = (AasRegistryTargetInformation) obj;
-		return Objects.equals(aasId, other.aasId);
+		return Objects.equals(aasIds, other.aasIds);
 	}
 
 	@Override
 	public String toString() {
-		return "AasTargetInformation [aasId=" + aasId + "]";
+		return "AasTargetInformation [aasIds=" + aasIds + "]";
 	}
 	
-	public String getAasId() {
-		return aasId;
+	public List<String> getAasIds() {
+		return aasIds;
 	}
 
 }

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/rbac/AasRegistryTargetPermissionVerifier.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/feature/authorization/rbac/AasRegistryTargetPermissionVerifier.java
@@ -29,6 +29,8 @@ import org.eclipse.digitaltwin.basyx.aasregistry.feature.authorization.AasRegist
 import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacRule;
 import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetPermissionVerifier;
 
+import java.util.List;
+
 /**
  * Verifies the {@link AasRegistryTargetInformation} against the {@link RbacRule}
  *
@@ -37,14 +39,26 @@ import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetPermissionVerifier
 public class AasRegistryTargetPermissionVerifier implements TargetPermissionVerifier<AasRegistryTargetInformation> {
 
 	public static final String ALL_ALLOWED_WILDCARD = "*";
-	
+
 	@Override
 	public boolean isVerified(RbacRule rbacRule, AasRegistryTargetInformation targetInformation) {
-		String shellId = targetInformation.getAasId();
-		
+		List<String> targetInformationShellIds = targetInformation.getAasIds();
+
 		AasRegistryTargetInformation rbacRuleAasTargetInformation = (AasRegistryTargetInformation) rbacRule.getTargetInformation();
-		
-		return rbacRuleAasTargetInformation.getAasId().equals(ALL_ALLOWED_WILDCARD) || rbacRuleAasTargetInformation.getAasId().equals(shellId);
+
+		List<String> rbacRuleShellIds = rbacRuleAasTargetInformation.getAasIds();
+
+		return areShellsAllowed(rbacRuleShellIds, targetInformationShellIds);
+	}
+
+	private boolean areShellsAllowed(List<String> rbacRuleShellIds, List<String> targetInformationShellIds) {
+
+		return allShellsAllowed(rbacRuleShellIds) || rbacRuleShellIds.containsAll(targetInformationShellIds);
+	}
+
+	private boolean allShellsAllowed(List<String> rbacRuleShellIds) {
+
+		return rbacRuleShellIds.size() == 1 && rbacRuleShellIds.get(0).equals(ALL_ALLOWED_WILDCARD);
 	}
 
 }

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/regression/feature/authorization/TestAuthorizedAasRegistry.java
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/regression/feature/authorization/TestAuthorizedAasRegistry.java
@@ -276,222 +276,222 @@ public class TestAuthorizedAasRegistry {
 	}
 
 	@Test
-	public void getSubmodelDescriptorsWithCorrectRoleAndPermission() throws IOException {
+	public void getAasDescriptorsWithCorrectRoleAndPermission() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_READER_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), accessToken);
 		assertEquals(HttpStatus.OK.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorsWithCorrectRoleAndSpecificAasDescriptorPermission() throws IOException {
+	public void getAasDescriptorsWithCorrectRoleAndSpecificAasDescriptorPermission() throws IOException {
 		DummyCredential dummyCredential = DummyCredentialStore.BASYX_READER_TWO_CREDENTIAL;
 
 		String accessToken = tokenProvider.getAccessToken(dummyCredential.getUsername(), dummyCredential.getPassword());
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), accessToken);
 		assertEquals(HttpStatus.OK.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorsWithCorrectRoleAndUnauthorizedSpecificAasDescriptor() throws IOException {
+	public void getAasDescriptorsWithCorrectRoleAndUnauthorizedSpecificAasDescriptor() throws IOException {
 		DummyCredential dummyCredential = DummyCredentialStore.BASYX_READER_TWO_CREDENTIAL;
 
 		String accessToken = tokenProvider.getAccessToken(dummyCredential.getUsername(), dummyCredential.getPassword());
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID_2), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID_2), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorsWithInsufficientPermissionRole() throws IOException {
+	public void getAasDescriptorsWithInsufficientPermissionRole() throws IOException {
 		DummyCredential dummyCredential = DummyCredentialStore.BASYX_UPDATER_CREDENTIAL;
 
 		String accessToken = tokenProvider.getAccessToken(dummyCredential.getUsername(), dummyCredential.getPassword());
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorsWithNoAuthorization() throws IOException {
-		CloseableHttpResponse retrievalResponse = getElementWithNoAuthorization(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID));
+	public void getAasDescriptorsWithNoAuthorization() throws IOException {
+		CloseableHttpResponse retrievalResponse = getElementWithNoAuthorization(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID));
 		assertEquals(HttpStatus.UNAUTHORIZED.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorWithCorrectRoleAndPermission() throws IOException {
+	public void getAasDescriptorWithCorrectRoleAndPermission() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_READER_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID), accessToken);
 		assertEquals(HttpStatus.OK.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
+	public void getAasDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
 		DummyCredential dummyCredential = DummyCredentialStore.BASYX_READER_TWO_CREDENTIAL;
 
 		String accessToken = tokenProvider.getAccessToken(dummyCredential.getUsername(), dummyCredential.getPassword());
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID), accessToken);
 		assertEquals(HttpStatus.OK.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
+	public void getAasDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
 		DummyCredential dummyCredential = DummyCredentialStore.BASYX_READER_TWO_CREDENTIAL;
 
 		String accessToken = tokenProvider.getAccessToken(dummyCredential.getUsername(), dummyCredential.getPassword());
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, SPECIFIC_SUBMODEL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, SPECIFIC_SUBMODEL_ID), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorWithInsufficientPermissionRole() throws IOException {
+	public void getAasDescriptorWithInsufficientPermissionRole() throws IOException {
 		DummyCredential dummyCredential = DummyCredentialStore.BASYX_UPDATER_CREDENTIAL;
 
 		String accessToken = tokenProvider.getAccessToken(dummyCredential.getUsername(), dummyCredential.getPassword());
 
-		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID), accessToken);
+		CloseableHttpResponse retrievalResponse = getElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void getSubmodelDescriptorWithNoAuthorization() throws IOException {
-		CloseableHttpResponse retrievalResponse = getElementWithNoAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID));
+	public void getAasDescriptorWithNoAuthorization() throws IOException {
+		CloseableHttpResponse retrievalResponse = getElementWithNoAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID, SPECIFIC_SUBMODEL_ID));
 		assertEquals(HttpStatus.UNAUTHORIZED.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void addSubmodelDescriptorWithCorrectRoleAndPermission() throws IOException {
+	public void addAasDescriptorWithCorrectRoleAndPermission() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_UPDATER_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
 		assertEquals(HttpStatus.CREATED.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void addSubmodelDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
+	public void addAasDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_UPDATER_TWO_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
 		assertEquals(HttpStatus.CREATED.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void addSubmodelDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
+	public void addAasDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_UPDATER_TWO_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID_2), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID_2), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void addSubmodelDescriptorWithInsufficientPermissionRole() throws IOException {
+	public void addAasDescriptorWithInsufficientPermissionRole() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_READER_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPostRequest(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void addSubmodelDescriptorWithNoAuthorization() throws IOException {
-		CloseableHttpResponse retrievalResponse = updateElementWithNoAuthorizationPostRequest(getSubmodelDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"));
+	public void addAasDescriptorWithNoAuthorization() throws IOException {
+		CloseableHttpResponse retrievalResponse = updateElementWithNoAuthorizationPostRequest(getAasDescriptorsAccessURL(SPECIFIC_SHELL_ID), getJSONStringFromFile("authorization/SingleSubmodelDescriptor.json"));
 
 		assertEquals(HttpStatus.UNAUTHORIZED.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void removeSubmodelDescriptorWithCorrectRoleAndPermission() throws IOException {
+	public void removeAasDescriptorWithCorrectRoleAndPermission() throws IOException {
 		createAasDescriptorOnRegistryWithAuthorization(aasRegistryBaseUrl, getJSONStringFromFile(AAS_DESCRIPTOR_SIMPLE_2_JSON), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_ASSET_UPDATER_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), accessToken);
+		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), accessToken);
 		assertEquals(HttpStatus.NO_CONTENT.value(), retrievalResponse.getCode());
 
 		deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 	}
 
 	@Test
-	public void removeSubmodelDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
+	public void removeAasDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
 		createAasDescriptorOnRegistryWithAuthorization(aasRegistryBaseUrl, getJSONStringFromFile(AAS_DESCRIPTOR_SIMPLE_2_JSON), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_ASSET_UPDATER_TWO_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), accessToken);
+		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), accessToken);
 		assertEquals(HttpStatus.NO_CONTENT.value(), retrievalResponse.getCode());
 
 		deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 	}
 
 	@Test
-	public void removeSubmodelDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
+	public void removeAasDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_ASSET_UPDATER_TWO_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID, "specificAasId-2-SM"), accessToken);
+		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID, "specificAasId-2-SM"), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void removeSubmodelDescriptorWithInsufficientPermissionRole() throws IOException {
+	public void removeAasDescriptorWithInsufficientPermissionRole() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_CREATOR_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), accessToken);
+		CloseableHttpResponse retrievalResponse = deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void removeSubmodelDescriptorWithNoAuthorization() throws IOException {
-		CloseableHttpResponse retrievalResponse = deleteElementWithNoAuthorization(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"));
+	public void removeAasDescriptorWithNoAuthorization() throws IOException {
+		CloseableHttpResponse retrievalResponse = deleteElementWithNoAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"));
 
 		assertEquals(HttpStatus.UNAUTHORIZED.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void replaceSubmodelDescriptorWithCorrectRoleAndPermission() throws IOException {
+	public void replaceAasDescriptorWithCorrectRoleAndPermission() throws IOException {
 		createAasDescriptorOnRegistryWithAuthorization(aasRegistryBaseUrl, getJSONStringFromFile(AAS_DESCRIPTOR_SIMPLE_2_JSON), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_ASSET_UPDATER_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
 		assertEquals(HttpStatus.NO_CONTENT.value(), retrievalResponse.getCode());
 
 		deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 	}
 
 	@Test
-	public void replaceSubmodelDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
+	public void replaceAasDescriptorWithCorrectRoleAndSpecificAasPermission() throws IOException {
 		createAasDescriptorOnRegistryWithAuthorization(aasRegistryBaseUrl, getJSONStringFromFile(AAS_DESCRIPTOR_SIMPLE_2_JSON), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_ASSET_UPDATER_TWO_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
 		assertEquals(HttpStatus.NO_CONTENT.value(), retrievalResponse.getCode());
 
 		deleteElementWithAuthorization(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2), getAccessToken(DummyCredentialStore.ADMIN_CREDENTIAL));
 	}
 
 	@Test
-	public void replaceSubmodelDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
+	public void replaceAasDescriptorWithCorrectRoleAndUnauthorizedSpecificAas() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_ASSET_UPDATER_TWO_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void replaceSubmodelDescriptorWithInsufficientPermissionRole() throws IOException {
+	public void replaceAasDescriptorWithInsufficientPermissionRole() throws IOException {
 		String accessToken = getAccessToken(DummyCredentialStore.BASYX_CREATOR_CREDENTIAL);
 
-		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
+		CloseableHttpResponse retrievalResponse = updateElementWithAuthorizationPutRequest(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"), accessToken);
 		assertEquals(HttpStatus.FORBIDDEN.value(), retrievalResponse.getCode());
 	}
 
 	@Test
-	public void replaceSubmodelDescriptorWithNoAuthorization() throws IOException {
-		CloseableHttpResponse retrievalResponse = updateElementWithNoAuthorizationPutRequest(getSpecificSubmodelDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"));
+	public void replaceAasDescriptorWithNoAuthorization() throws IOException {
+		CloseableHttpResponse retrievalResponse = updateElementWithNoAuthorizationPutRequest(getSpecificAasDescriptorAccessURL(SPECIFIC_SHELL_ID_2, "specificAasId-2-SM"), getJSONStringFromFile("authorization/SingleSubmodelDescriptor_Update.json"));
 
 		assertEquals(HttpStatus.UNAUTHORIZED.value(), retrievalResponse.getCode());
 	}
@@ -592,12 +592,12 @@ public class TestAuthorizedAasRegistry {
 		return BASE_URL + "/search";
 	}
 
-	private String getSubmodelDescriptorsAccessURL(String shellId) {
+	private String getAasDescriptorsAccessURL(String shellId) {
 		return getSpecificAasDescriptorAccessURL(shellId) + "/submodel-descriptors";
 	}
 
-	private String getSpecificSubmodelDescriptorAccessURL(String shellId, String submodelId) {
-		return getSubmodelDescriptorsAccessURL(shellId) + "/" + Base64UrlEncodedIdentifier.encodeIdentifier(submodelId);
+	private String getSpecificAasDescriptorAccessURL(String shellId, String submodelId) {
+		return getAasDescriptorsAccessURL(shellId) + "/" + Base64UrlEncodedIdentifier.encodeIdentifier(submodelId);
 	}
 
 	private CloseableHttpResponse deleteElementWithNoAuthorization(String url) throws IOException {

--- a/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/test/resources/rbac_rules.json
+++ b/basyx.aasregistry/basyx.aasregistry-feature-authorization/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": ["dummyShellId_3", "dummyShellId_4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": "dummyShellId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   }
 ]

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/src/test/resources/rbac_rules.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": ["dummyShellId_3", "dummyShellId_4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": "dummyShellId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   }
 ]

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/test/resources/rbac_rules.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": ["dummyShellId_3", "dummyShellId_4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": "dummyShellId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   }
 ]

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/src/test/resources/rbac_rules.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": ["dummyShellId_3", "dummyShellId_4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": "dummyShellId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   }
 ]

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/src/test/resources/rbac_rules.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": ["dummyShellId_3", "dummyShellId_4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "dummyShellId_3"
+      "aasIds": "dummyShellId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "*"
+      "aasIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "aas-registry",
-      "aasId": "specificAasId-2"
+      "aasIds": "specificAasId-2"
     }
   }
 ]

--- a/basyx.submodelregistry/basyx.submodelregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/feature/authorization/SubmodelRegistryTargetInformation.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/feature/authorization/SubmodelRegistryTargetInformation.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.List;
 
 import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetInformation;
 import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetInformationSubtype;
@@ -42,23 +43,23 @@ import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetInformationSubtype
 @TargetInformationSubtype(getValue = "submodel-registry")
 public class SubmodelRegistryTargetInformation implements TargetInformation {
 	
-	private String submodelId;
+	private List<String> submodelIds;
 
 	@JsonCreator
-	public SubmodelRegistryTargetInformation(final @JsonProperty("submodelId") String submodelId) {
-		this.submodelId = submodelId;
+	public SubmodelRegistryTargetInformation(final @JsonProperty("submodelIds") List<String> submodelIds) {
+		this.submodelIds = submodelIds;
 	}
 
 	@Override
 	public Map<String, Object> toMap() {
 		final Map<String, Object> map = new HashMap<>();
-		map.put("submodelId", submodelId);
+		map.put("submodelIds", submodelIds);
 		return map;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(submodelId);
+		return Objects.hash(submodelIds);
 	}
 
 	@Override
@@ -70,16 +71,16 @@ public class SubmodelRegistryTargetInformation implements TargetInformation {
 		if (getClass() != obj.getClass())
 			return false;
 		SubmodelRegistryTargetInformation other = (SubmodelRegistryTargetInformation) obj;
-		return Objects.equals(submodelId, other.submodelId);
+		return Objects.equals(submodelIds, other.submodelIds);
 	}
 
 	@Override
 	public String toString() {
-		return "SubmodelTargetInformation [submodelId=" + submodelId + "]";
+		return "SubmodelTargetInformation [submodelIds=" + submodelIds + "]";
 	}
 	
-	public String getSubmodelId() {
-		return submodelId;
+	public List<String> getSubmodelIds() {
+		return submodelIds;
 	}
 
 }

--- a/basyx.submodelregistry/basyx.submodelregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/feature/authorization/rbac/SubmodelRegistryTargetPermissionVerifier.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/feature/authorization/rbac/SubmodelRegistryTargetPermissionVerifier.java
@@ -29,6 +29,8 @@ import org.eclipse.digitaltwin.basyx.submodelregistry.feature.authorization.Subm
 import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacRule;
 import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetPermissionVerifier;
 
+import java.util.List;
+
 /**
  * Verifies the {@link SubmodelRegistryTargetInformation} against the {@link RbacRule}
  *
@@ -37,14 +39,25 @@ import org.eclipse.digitaltwin.basyx.authorization.rbac.TargetPermissionVerifier
 public class SubmodelRegistryTargetPermissionVerifier implements TargetPermissionVerifier<SubmodelRegistryTargetInformation> {
 
 	public static final String ALL_ALLOWED_WILDCARD = "*";
-	
+
 	@Override
 	public boolean isVerified(RbacRule rbacRule, SubmodelRegistryTargetInformation targetInformation) {
-		String submodelId = targetInformation.getSubmodelId();
-		
+		List<String> targetInformationSubmodelIds = targetInformation.getSubmodelIds();
+
 		SubmodelRegistryTargetInformation rbacRuleSubmodelTargetInformation = (SubmodelRegistryTargetInformation) rbacRule.getTargetInformation();
-		
-		return rbacRuleSubmodelTargetInformation.getSubmodelId().equals(ALL_ALLOWED_WILDCARD) || rbacRuleSubmodelTargetInformation.getSubmodelId().equals(submodelId);
+
+		List<String> rbacRuleSubmodelIds = rbacRuleSubmodelTargetInformation.getSubmodelIds();
+
+		return areSubmodelsAllowed(rbacRuleSubmodelIds, targetInformationSubmodelIds);
+	}
+
+	private boolean areSubmodelsAllowed(List<String> rbacRuleSubmodelIds, List<String> targetInformationSubmodelIds) {
+		return allSubmodelsAllowed(rbacRuleSubmodelIds) || rbacRuleSubmodelIds.containsAll(targetInformationSubmodelIds);
+	}
+
+	private boolean allSubmodelsAllowed(List<String> rbacRuleSubmodelIds) {
+
+		return rbacRuleSubmodelIds.size() == 1 && rbacRuleSubmodelIds.get(0).equals(ALL_ALLOWED_WILDCARD);
 	}
 
 }

--- a/basyx.submodelregistry/basyx.submodelregistry-feature-authorization/src/test/resources/rbac_rules.json
+++ b/basyx.submodelregistry/basyx.submodelregistry-feature-authorization/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": ["dummySubmodelId_3", "specificSubmodelId-4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": "dummySubmodelId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   }
 ]

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mem/src/test/resources/rbac_rules.json
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mem/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": ["dummySubmodelId_3", "specificSubmodelId-4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": "dummySubmodelId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   }
 ]

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mongodb/src/test/resources/rbac_rules.json
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mongodb/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": ["dummySubmodelId_3", "specificSubmodelId-4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": "dummySubmodelId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   }
 ]

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mem/src/test/resources/rbac_rules.json
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mem/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": ["dummySubmodelId_3", "specificSubmodelId-4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": "dummySubmodelId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   }
 ]

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mongodb/src/test/resources/rbac_rules.json
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mongodb/src/test/resources/rbac_rules.json
@@ -4,7 +4,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -12,7 +12,7 @@
     "action": ["CREATE", "READ", "UPDATE", "DELETE"],
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -20,7 +20,7 @@
     "action": "READ",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": ["dummySubmodelId_3", "specificSubmodelId-4"]
     }
   },
   {
@@ -28,7 +28,7 @@
     "action": "CREATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -36,7 +36,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -44,7 +44,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "dummySubmodelId_3"
+      "submodelIds": "dummySubmodelId_3"
     }
   },
   {
@@ -52,7 +52,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -60,7 +60,7 @@
     "action": "UPDATE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   },
   {
@@ -68,7 +68,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "*"
+      "submodelIds": "*"
     }
   },
   {
@@ -76,7 +76,7 @@
     "action": "DELETE",
     "targetInformation": {
       "@type": "submodel-registry",
-      "submodelId": "specificSubmodelId-2"
+      "submodelIds": "specificSubmodelId-2"
     }
   }
 ]


### PR DESCRIPTION
As an Administrator I want to configure multiple Descriptor Information inside the RBAC Rules so that I don't have to repeat access control policies for each Descriptor.