### PR TITLE
Registry: ObjectMapperTest Failing

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/ObjectMapperTest.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/ObjectMapperTest.java
@@ -1,0 +1,30 @@
+package org.eclipse.digitaltwin.basyx.aasregistry.service.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.eclipse.digitaltwin.basyx.aasregistry.client.ApiClient;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectMapperTest {
+
+	@Test
+	void emptyCollection_excludedFromJson() {
+		ApiClient apiClient = new ApiClient();
+		ObjectMapper objectMapper = apiClient.getObjectMapper();
+		AssetAdministrationShellDescriptor descr = new AssetAdministrationShellDescriptor();
+		descr.id("descriptor_with_empty_list");
+		descr.description(Collections.emptyList());
+
+		JsonNode jsonNode = objectMapper.valueToTree(descr);
+		JsonNode description = jsonNode.get("description");
+
+		assertThat(description).isNull();
+	}
+
+}


### PR DESCRIPTION
Hey, 
we are having problems with publishing descriptors to the registry. The `objectMapper` in `org.eclipse.digitaltwin.basyx.aasregistry.client.api.RegistryAndDiscoveryInterfaceApi` used to post a descriptor to the registry is mapping empty lists to an empty array instead of excluding them, as the deserializer would expect, resulting in `BAD_REQUEST`.

I have written this test to further clarify the problem we are facing. So, it is not actually a fix but rather a proof 🙂
