### PR TITLE
Fixes token retrieval mechanism issue in Authorized version of Connected client versions in AAS/SM Service

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/ConnectedAasManager.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/ConnectedAasManager.java
@@ -145,7 +145,7 @@ public class ConnectedAasManager {
 	public List<ConnectedSubmodelService> getAllSubmodels(String shellIdentifier) {
 		AssetAdministrationShell shell = getAasService(shellIdentifier).getAAS();
 		List<Reference> submodelReferences = shell.getSubmodels();
-		return submodelReferences.parallelStream()
+		return submodelReferences.stream()
 				.map(this::extractSubmodelIdentifierFromReference)
 				.map(this::getSubmodelService)
 				.collect(Collectors.toList());

--- a/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/AuthorizedConnectedAasService.java
+++ b/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/AuthorizedConnectedAasService.java
@@ -25,9 +25,6 @@
 
 package org.eclipse.digitaltwin.basyx.aasservice.client;
 
-import java.io.IOException;
-import java.net.http.HttpRequest;
-
 import org.eclipse.digitaltwin.basyx.aasservice.client.internal.AssetAdministrationShellServiceApi;
 import org.eclipse.digitaltwin.basyx.client.internal.authorization.TokenManager;
 
@@ -46,16 +43,7 @@ public class AuthorizedConnectedAasService extends ConnectedAasService {
 	 * @param tokenManager
 	 */
 	public AuthorizedConnectedAasService(String repoUrl, TokenManager tokenManager) {
-		super(new AssetAdministrationShellServiceApi(repoUrl, getRequestBuilder(tokenManager)));
-	}
-	
-	private static HttpRequest.Builder getRequestBuilder(TokenManager tokenManager) {
-		try {
-			return HttpRequest.newBuilder()
-			        .header("Authorization", "Bearer " + tokenManager.getAccessToken());
-		} catch (IOException e) {
-			throw new RuntimeException("Unable to request access token");
-		}
+		super(new AssetAdministrationShellServiceApi(repoUrl, tokenManager));
 	}
 
 }

--- a/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/internal/AssetAdministrationShellServiceApi.java
+++ b/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/internal/AssetAdministrationShellServiceApi.java
@@ -57,6 +57,8 @@ import org.eclipse.digitaltwin.basyx.client.internal.ApiClient;
 import org.eclipse.digitaltwin.basyx.client.internal.ApiException;
 import org.eclipse.digitaltwin.basyx.client.internal.ApiResponse;
 import org.eclipse.digitaltwin.basyx.client.internal.Pair;
+import org.eclipse.digitaltwin.basyx.client.internal.authorization.TokenManager;
+import org.eclipse.digitaltwin.basyx.core.exceptions.AccessTokenRetrievalException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.http.description.ServiceDescription;
 import org.eclipse.digitaltwin.basyx.http.pagination.Base64UrlEncodedCursorResult;
@@ -73,36 +75,33 @@ public class AssetAdministrationShellServiceApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  private HttpRequest.Builder httpRequestBuilder;
+  private TokenManager tokenManager;
 
   public AssetAdministrationShellServiceApi() {
     this(new ApiClient());
-    this.httpRequestBuilder = HttpRequest.newBuilder();
   }
   
-  public AssetAdministrationShellServiceApi(HttpRequest.Builder httpRequestBuilder) {
-		this();
-		this.httpRequestBuilder = httpRequestBuilder;
-}
+  public AssetAdministrationShellServiceApi(TokenManager tokenManager) {
+	    this(new ApiClient());
+	    this.tokenManager = tokenManager;
+	  }
 
   public AssetAdministrationShellServiceApi(ObjectMapper mapper, String baseUri) {
     this(new ApiClient(HttpClient.newBuilder(), mapper, baseUri));
-    this.httpRequestBuilder = HttpRequest.newBuilder();
   }
   
-  public AssetAdministrationShellServiceApi(ObjectMapper mapper, String baseUri, HttpRequest.Builder httpRequestBuilder) {
-		this(mapper, baseUri);
-		this.httpRequestBuilder = httpRequestBuilder;
-}
+  public AssetAdministrationShellServiceApi(ObjectMapper mapper, String baseUri, TokenManager tokenManager) {
+	    this(new ApiClient(HttpClient.newBuilder(), mapper, baseUri));
+	    this.tokenManager = tokenManager;
+  }
   
   public AssetAdministrationShellServiceApi(String baseUri) {
 		this(new ApiClient(HttpClient.newBuilder(), new JsonMapperFactory().create(new SimpleAbstractTypeResolverFactory().create()), baseUri));
-		this.httpRequestBuilder = HttpRequest.newBuilder();
   }
   
-  public AssetAdministrationShellServiceApi(String baseUri, HttpRequest.Builder httpRequestBuilder) {
-		this(baseUri);
-		this.httpRequestBuilder = httpRequestBuilder;
+  public AssetAdministrationShellServiceApi(String baseUri, TokenManager tokenManager) {
+		this(new ApiClient(HttpClient.newBuilder(), new JsonMapperFactory().create(new SimpleAbstractTypeResolverFactory().create()), baseUri));
+		this.tokenManager = tokenManager;
   }
 
 
@@ -201,13 +200,15 @@ public class AssetAdministrationShellServiceApi {
 			throw new ApiException(400, "Missing the required parameter 'submodelIdentifier' when calling deleteSubmodelReferenceById");
 		}
 
+		HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
 		String localVarPath = "/submodel-refs/{submodelIdentifier}".replace("{submodelIdentifier}", ApiClient.urlEncode(submodelIdentifier.toString()));
-		
-		HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
 		localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
 		localVarRequestBuilder.header("Accept", "application/json");
+		
+		addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 		localVarRequestBuilder.method("DELETE", HttpRequest.BodyPublishers.noBody());
 		if (memberVarReadTimeout != null) {
@@ -284,13 +285,15 @@ public class AssetAdministrationShellServiceApi {
 
   private HttpRequest.Builder deleteThumbnailRequestBuilder() throws ApiException {
 
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
 	String localVarPath = "/asset-information/thumbnail";
-	
-	HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("DELETE", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -348,9 +351,9 @@ public class AssetAdministrationShellServiceApi {
 
   private HttpRequest.Builder getAllSubmodelReferencesRequestBuilder(Integer limit, String cursor) throws ApiException {
 
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
     String localVarPath = "/submodel-refs";
-    
-    HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
     List<Pair> localVarQueryParams = new ArrayList<>();
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
@@ -369,6 +372,8 @@ public class AssetAdministrationShellServiceApi {
     }
 
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -440,11 +445,13 @@ public class AssetAdministrationShellServiceApi {
 
   private HttpRequest.Builder getAssetAdministrationShellRequestBuilder() throws ApiException {
 
-	HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();  
-	
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
 	localVarRequestBuilder.uri(URI.create(memberVarBaseUri));
 
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -523,6 +530,8 @@ public class AssetAdministrationShellServiceApi {
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -594,13 +603,15 @@ public class AssetAdministrationShellServiceApi {
 
   private HttpRequest.Builder getAssetInformationRequestBuilder() throws ApiException {
 
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
 	String localVarPath = "/asset-information";
-	
-	HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -679,6 +690,8 @@ public class AssetAdministrationShellServiceApi {
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -748,13 +761,15 @@ public class AssetAdministrationShellServiceApi {
 
   private HttpRequest.Builder getThumbnailRequestBuilder() throws ApiException {
 
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
 	String localVarPath = "/asset-information/thumbnail";
-	
-	HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Accept", "application/octet-stream, application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
     if (memberVarReadTimeout != null) {
@@ -833,14 +848,16 @@ public class AssetAdministrationShellServiceApi {
       throw new ApiException(400, "Missing the required parameter 'reference' when calling postSubmodelReference");
     }
 
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
     String localVarPath = "/submodel-refs";
-    
-    HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Content-Type", "application/json");
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     try {
       byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(reference);
@@ -935,6 +952,8 @@ public class AssetAdministrationShellServiceApi {
 
     localVarRequestBuilder.header("Content-Type", "application/json");
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     try {
       byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(assetAdministrationShell);
@@ -1021,14 +1040,16 @@ public class AssetAdministrationShellServiceApi {
       throw new ApiException(400, "Missing the required parameter 'assetInformation' when calling putAssetInformation");
     }
 
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
 	String localVarPath = "/asset-information";
-	
-	HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
     localVarRequestBuilder.header("Content-Type", "application/json");
     localVarRequestBuilder.header("Accept", "application/json");
+    
+    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
     try {
       byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(assetInformation);
@@ -1087,11 +1108,8 @@ public class AssetAdministrationShellServiceApi {
 	}
 
 	private HttpRequest.Builder putThumbnailRequestBuilder(String fileName, ContentType contentType, InputStream inputStream) throws ApiException {
-		
+		HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 		String localVarPath = "/asset-information/thumbnail";
-		
-		HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
-		
 		localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 		localVarRequestBuilder.header("Accept", "application/json");
 
@@ -1118,6 +1136,8 @@ public class AssetAdministrationShellServiceApi {
 		HttpRequest.BodyPublisher formDataPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> Channels.newInputStream(pipe.source()));
 
 		localVarRequestBuilder.header("Content-Type", entity.getContentType().getValue()).method("PUT", formDataPublisher);
+		
+		addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 		if (memberVarReadTimeout != null) {
 			localVarRequestBuilder.timeout(memberVarReadTimeout);
@@ -1139,6 +1159,17 @@ public class AssetAdministrationShellServiceApi {
 
 	private static String buildUniqueFilename() {
 		return UUID.randomUUID().toString();
+	}
+	
+	private void addAuthorizationHeaderIfAuthIsEnabled(HttpRequest.Builder localVarRequestBuilder) {
+		if (tokenManager != null) {
+	    	try {
+	    		localVarRequestBuilder.header("Authorization", "Bearer " + tokenManager.getAccessToken());
+			} catch (IOException e) {
+				e.printStackTrace();
+				throw new AccessTokenRetrievalException("Unable to request access token");
+			}
+	    }
 	}
 
 }

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/AuthorizedConnectedSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/AuthorizedConnectedSubmodelService.java
@@ -25,9 +25,6 @@
 
 package org.eclipse.digitaltwin.basyx.submodelservice.client;
 
-import java.io.IOException;
-import java.net.http.HttpRequest;
-
 import org.eclipse.digitaltwin.basyx.client.internal.authorization.TokenManager;
 import org.eclipse.digitaltwin.basyx.submodelservice.client.internal.SubmodelServiceApi;
 
@@ -46,17 +43,7 @@ public class AuthorizedConnectedSubmodelService extends ConnectedSubmodelService
 	 * @param tokenManager
 	 */
 	public AuthorizedConnectedSubmodelService(String repoUrl, TokenManager tokenManager) {
-		super(new SubmodelServiceApi(repoUrl, getRequestBuilder(tokenManager)));
-	}
-	
-	private static HttpRequest.Builder getRequestBuilder(TokenManager tokenManager) {
-		try {
-			return HttpRequest.newBuilder()
-			        .header("Authorization", "Bearer " + tokenManager.getAccessToken());
-		} catch (IOException e) {
-			e.printStackTrace();
-			throw new RuntimeException("Unable to request access token");
-		}
+		super(new SubmodelServiceApi(repoUrl, tokenManager));
 	}
 
 }

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/internal/SubmodelServiceApi.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/internal/SubmodelServiceApi.java
@@ -56,6 +56,8 @@ import org.eclipse.digitaltwin.basyx.client.internal.ApiClient;
 import org.eclipse.digitaltwin.basyx.client.internal.ApiException;
 import org.eclipse.digitaltwin.basyx.client.internal.ApiResponse;
 import org.eclipse.digitaltwin.basyx.client.internal.Pair;
+import org.eclipse.digitaltwin.basyx.client.internal.authorization.TokenManager;
+import org.eclipse.digitaltwin.basyx.core.exceptions.AccessTokenRetrievalException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.http.pagination.Base64UrlEncodedCursorResult;
 import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelElementValue;
@@ -73,38 +75,36 @@ public class SubmodelServiceApi {
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
   private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-	private final Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
-	private HttpRequest.Builder httpRequestBuilder;
+  private final Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
+	
+  private TokenManager tokenManager;
 
   public SubmodelServiceApi() {
     this(new ApiClient());
-    this.httpRequestBuilder = HttpRequest.newBuilder();
   }
   
-  public SubmodelServiceApi(HttpRequest.Builder httpRequestBuilder) {
-		this();
-		this.httpRequestBuilder = httpRequestBuilder;
+  public SubmodelServiceApi(TokenManager tokenManager) {
+	    this(new ApiClient());
+	    this.tokenManager = tokenManager;
   }
 
   public SubmodelServiceApi(ObjectMapper mapper, String baseUri) {
     this(new ApiClient(HttpClient.newBuilder(), mapper, baseUri));
-    this.httpRequestBuilder = HttpRequest.newBuilder();
   }
   
-  public SubmodelServiceApi(ObjectMapper mapper, String baseUri, HttpRequest.Builder httpRequestBuilder) {
-		this(mapper, baseUri);
-		this.httpRequestBuilder = httpRequestBuilder;
+  public SubmodelServiceApi(ObjectMapper mapper, String baseUri, TokenManager tokenManager) {
+	    this(new ApiClient(HttpClient.newBuilder(), mapper, baseUri));
+	    this.tokenManager = tokenManager;
   }
 
-	public SubmodelServiceApi(String baseUri) {
+  public SubmodelServiceApi(String baseUri) {
 		this(new ApiClient(HttpClient.newBuilder(), new SubmodelSpecificJsonMapperFactory().create(), baseUri));
-		this.httpRequestBuilder = HttpRequest.newBuilder();
-	}
+  }
 
-	public SubmodelServiceApi(String baseUri, HttpRequest.Builder httpRequestBuilder) {
-		this(baseUri);
-		this.httpRequestBuilder = httpRequestBuilder;
-	}
+  public SubmodelServiceApi(String baseUri, TokenManager tokenManager) {
+	  	this(new ApiClient(HttpClient.newBuilder(), new SubmodelSpecificJsonMapperFactory().create(), baseUri));
+	  	this.tokenManager = tokenManager;
+  }
 
 
 
@@ -208,7 +208,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 	private HttpRequest.Builder getSubmodelRequestBuilder(String level, String extent) throws ApiException {
 
-		HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+		HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 		String localVarPath = "";
 
@@ -232,6 +232,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		}
 
 		localVarRequestBuilder.header("Accept", "application/json");
+		
+		addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 		localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
 		if (memberVarReadTimeout != null) {
@@ -330,7 +332,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling getSubmodelElementByPath");
 		}
 
-		HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+		HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 		String localVarPath = "/submodel-elements/{idShortPath}".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
@@ -354,6 +356,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		}
 
 		localVarRequestBuilder.header("Accept", "application/json");
+		
+		addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 		localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
 		if (memberVarReadTimeout != null) {
@@ -455,7 +459,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling getSubmodelElementByPathValueOnly");
 		}
 
-		HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+		HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 		String localVarPath = "/submodel-elements/{idShortPath}/$value".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
@@ -479,6 +483,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		}
 
 		localVarRequestBuilder.header("Accept", "application/json");
+		
+		addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 		localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
 		if (memberVarReadTimeout != null) {
@@ -596,7 +602,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			throw new ApiException(400, "Missing the required parameter 'getSubmodelElementsValueResult' when calling patchSubmodelElementByPathValueOnly");
 		}
 
-		HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+		HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 		String localVarPath = "/submodel-elements/{idShortPath}/$value".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
@@ -623,6 +629,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 		localVarRequestBuilder.header("Content-Type", "application/json");
 		localVarRequestBuilder.header("Accept", "application/json");
+		
+		addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 		try {
 			byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(getSubmodelElementsValueResult);
@@ -707,7 +715,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 	      throw new ApiException(400, "Missing the required parameter 'submodelElement' when calling postSubmodelElement");
 	    }
 
-	    HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+	    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 		String localVarPath = "/submodel-elements";
 
@@ -715,6 +723,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 	    localVarRequestBuilder.header("Content-Type", "application/json");
 	    localVarRequestBuilder.header("Accept", "application/json");
+	    
+	    addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 	    try {
 	      byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(submodelElement);
@@ -812,7 +822,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 				throw new ApiException(400, "Missing the required parameter 'submodelElement' when calling postSubmodelElementByPath");
 			}
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
@@ -820,6 +830,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 			localVarRequestBuilder.header("Content-Type", "application/json");
 			localVarRequestBuilder.header("Accept", "application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			try {
 				byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(submodelElement);
@@ -927,7 +939,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 				throw new ApiException(400, "Missing the required parameter 'submodelElement' when calling putSubmodelElementByPath");
 			}
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
@@ -950,6 +962,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 			localVarRequestBuilder.header("Content-Type", "application/json");
 			localVarRequestBuilder.header("Accept", "application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			try {
 				byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(submodelElement);
@@ -1038,13 +1052,15 @@ public SubmodelServiceApi(ApiClient apiClient) {
 				throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling deleteSubmodelElementByPath");
 			}
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
 			localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
 			localVarRequestBuilder.header("Accept", "application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			localVarRequestBuilder.method("DELETE", HttpRequest.BodyPublishers.noBody());
 			if (memberVarReadTimeout != null) {
@@ -1109,7 +1125,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 		private HttpRequest.Builder getAllSubmodelElementsRequestBuilder(Integer limit, String cursor, String level, String extent) throws ApiException {
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements";
 
@@ -1137,6 +1153,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			}
 
 			localVarRequestBuilder.header("Accept", "application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
 			if (memberVarReadTimeout != null) {
@@ -1198,7 +1216,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			if (inputStream == null)
 				throw new ApiException(400, "Missing the required parameter 'inputStream' when calling putFileByPath");
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}/attachment".replace("{idShortPath}", ApiClient.urlEncode(idShortPath));
 
@@ -1225,6 +1243,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			formDataPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> Channels.newInputStream(pipe.source()));
 
 			localVarRequestBuilder.header("Content-Type", entity.getContentType().getValue()).method("PUT", formDataPublisher);
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			if (memberVarReadTimeout != null) {
 				localVarRequestBuilder.timeout(memberVarReadTimeout);
@@ -1307,13 +1327,15 @@ public SubmodelServiceApi(ApiClient apiClient) {
 				throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling deleteFileByPath");
 			}
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}/attachment".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
 			localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
 			localVarRequestBuilder.header("Accept", "application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			localVarRequestBuilder.method("DELETE", HttpRequest.BodyPublishers.noBody());
 			if (memberVarReadTimeout != null) {
@@ -1374,13 +1396,15 @@ public SubmodelServiceApi(ApiClient apiClient) {
 				throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling getFileByPath");
 			}
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}/attachment".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
 			localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
 			localVarRequestBuilder.header("Accept", "application/octet-stream, application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
 			if (memberVarReadTimeout != null) {
@@ -1471,7 +1495,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 				throw new ApiException(400, "Missing the required parameter 'operationRequest' when calling invokeOperation");
 			}
 
-			HttpRequest.Builder localVarRequestBuilder = this.httpRequestBuilder.copy();
+			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
 			String localVarPath = "/submodel-elements/{idShortPath}/invoke".replace("{idShortPath}", ApiClient.urlEncode(idShortPath.toString()));
 
@@ -1479,6 +1503,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 			localVarRequestBuilder.header("Content-Type", "application/json");
 			localVarRequestBuilder.header("Accept", "application/json");
+			
+			addAuthorizationHeaderIfAuthIsEnabled(localVarRequestBuilder);
 
 			try {
 				byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(operationRequest);
@@ -1506,5 +1532,16 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 		private static String buildUniqueFilename() {
 			return UUID.randomUUID().toString();
+		}
+		
+		private void addAuthorizationHeaderIfAuthIsEnabled(HttpRequest.Builder localVarRequestBuilder) {
+			if (tokenManager != null) {
+		    	try {
+		    		localVarRequestBuilder.header("Authorization", "Bearer " + tokenManager.getAccessToken());
+				} catch (IOException e) {
+					e.printStackTrace();
+					throw new AccessTokenRetrievalException("Unable to request access token");
+				}
+		    }
 		}
 }


### PR DESCRIPTION
## Description of Changes

This PR addresses the same fix applied by #355 but in AAS and SM service.

The Authorized versions of clients for AAS/SM Service was using wrong mechanism to retrieve access tokens, because of this wrong behavior, new token was not getting retrieved once the initial token was expired.

This PR removes the one-time addition of the Authorization header at the time of instantiation of AuthorizedConnected*, and pass the TokenManager directly to the APIs, so that token can be requested each time and not use a single token for each request.

