### PR TITLE
Updates docker base image and adds support for arm/v7

### DIFF
--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
+++ b/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
+++ b/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
+++ b/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mem/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mem/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mem/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mem/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mongodb/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM amazoncorretto:17 as builder
+FROM eclipse-temurin:17 as builder
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.submodelservice/basyx.submodelservice.example/Dockerfile
+++ b/basyx.submodelservice/basyx.submodelservice.example/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17
+FROM eclipse-temurin:17
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<docker.namespace>eclipsebasyx</docker.namespace>
 		<docker.image.name>NOT_DEFINED_IN_MODULE</docker.image.name>
 		<docker.image.tag>${revision}</docker.image.tag>
-		<docker.target.platforms>linux/amd64, linux/arm64</docker.target.platforms>
+		<docker.target.platforms>linux/amd64, linux/arm64, linux/arm/v7</docker.target.platforms>
 		<docker.host.port>8081</docker.host.port>
 		<docker.container.port>8081</docker.container.port>
 		<aas4j-version>1.0.2</aas4j-version>


### PR DESCRIPTION
# arm/v7 support

## Description of Changes

This PR updates the base image of the dockerfiles to `eclipse-temurin:17` and therefore replaces `amazoncoretto:17`. This allows for also releasing BaSyx Java V2 for the arm/v7 architecture which is common for older microcontrollers like the Raspberry Pi or industrial controllers (PLCs) like the Wago PFC200.