### PR TITLE
Fix default endpoint resolve strategy from client lib not conforming with specification

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/resolvers/AasDescriptorResolver.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/resolvers/AasDescriptorResolver.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.Endpoint;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.ProtocolInformation;
 import org.eclipse.digitaltwin.basyx.aasservice.client.ConnectedAasService;
 import org.eclipse.digitaltwin.basyx.client.internal.resolver.DescriptorResolver;
 
@@ -40,6 +41,8 @@ import org.eclipse.digitaltwin.basyx.client.internal.resolver.DescriptorResolver
  *
  */
 public class AasDescriptorResolver implements DescriptorResolver<AssetAdministrationShellDescriptor, ConnectedAasService> {
+
+	static final String SPEC_INTERFACE = "AAS-3.0";
 
 	private final EndpointResolver endpointResolver;
 
@@ -66,16 +69,7 @@ public class AasDescriptorResolver implements DescriptorResolver<AssetAdministra
 
 	public static Optional<URI> parseEndpoint(Endpoint endpoint) {
 		try {
-			if (endpoint == null || endpoint.getProtocolInformation() == null || endpoint.getProtocolInformation()
-					.getHref() == null)
-				return Optional.empty();
-
-			String baseHref = endpoint.getProtocolInformation()
-					.getHref();
-			// TODO not working: String queryString = "?" + endpoint.toUrlQueryString();
-			String queryString = "";
-			URI uri = new URI(baseHref + queryString);
-			return Optional.of(uri);
+			return Optional.ofNullable(endpoint).filter(ep -> ep.getInterface().equals(SPEC_INTERFACE)).map(Endpoint::getProtocolInformation).map(ProtocolInformation::getHref).map(URI::create);
 		} catch (Exception e) {
 			return Optional.empty();
 		}

--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/resolvers/SubmodelDescriptorResolver.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/resolvers/SubmodelDescriptorResolver.java
@@ -25,6 +25,7 @@
 
 package org.eclipse.digitaltwin.basyx.aasenvironment.client.resolvers;
 
+import org.eclipse.digitaltwin.basyx.submodelregistry.client.model.ProtocolInformation;
 import org.eclipse.digitaltwin.basyx.client.internal.resolver.DescriptorResolver;
 import java.net.URI;
 import java.util.Optional;
@@ -40,6 +41,8 @@ import org.eclipse.digitaltwin.basyx.submodelservice.client.ConnectedSubmodelSer
  *
  */
 public class SubmodelDescriptorResolver implements DescriptorResolver<SubmodelDescriptor, ConnectedSubmodelService> {
+
+	static final String SPEC_INTERFACE = "SUBMODEL-3.0";
 
 	private final EndpointResolver endpointResolver;
 
@@ -67,16 +70,7 @@ public class SubmodelDescriptorResolver implements DescriptorResolver<SubmodelDe
 
 	public static Optional<URI> parseEndpoint(Endpoint endpoint) {
 		try {
-			if (endpoint == null || endpoint.getProtocolInformation() == null || endpoint.getProtocolInformation()
-					.getHref() == null)
-				return Optional.empty();
-
-			String baseHref = endpoint.getProtocolInformation()
-					.getHref();
-			// TODO not working: String queryString = "?" + endpoint.toUrlQueryString();
-			String queryString = "";
-			URI uri = new URI(baseHref + queryString);
-			return Optional.of(uri);
+			return Optional.ofNullable(endpoint).filter(ep -> ep.getInterface().equals(SPEC_INTERFACE)).map(Endpoint::getProtocolInformation).map(ProtocolInformation::getHref).map(URI::create);
 		} catch (Exception e) {
 			return Optional.empty();
 		}

--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/TestFixture.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/TestFixture.java
@@ -25,6 +25,8 @@
 
 package org.eclipse.digitaltwin.basyx.aasenvironment.client;
 
+import java.util.LinkedList;
+
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
@@ -38,6 +40,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultKey;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.Endpoint;
 import org.eclipse.digitaltwin.basyx.aasregistry.main.client.mapper.DummyAasDescriptorFactory;
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncoder;
 import org.eclipse.digitaltwin.basyx.submodelregistry.client.mapper.AttributeMapper;
@@ -91,6 +94,15 @@ public class TestFixture {
 		return DummyAasDescriptorFactory.createDummyDescriptor(AAS_PRE1_ID, AAS_PRE1_IDSHORT, AAS_PRE1_GLOBALASSETID, aasRepositoryBasePath);
 	}
 
+	public AssetAdministrationShellDescriptor buildAasPre1Descriptor_withMultipleInterfaces() {
+		LinkedList<Endpoint> endpoints = new LinkedList<>();
+
+		endpoints.add(DummyAasDescriptorFactory.createEndpoint(AAS_POS1_ID, aasRepositoryBasePath, "OTHER-3.0"));
+		endpoints.add(DummyAasDescriptorFactory.createEndpoint(AAS_PRE1_ID, aasRepositoryBasePath, "AAS-3.0"));
+
+		return DummyAasDescriptorFactory.createDummyDescriptor(AAS_PRE1_ID, AAS_PRE1_IDSHORT, AAS_PRE1_GLOBALASSETID, endpoints);
+	}
+
 	public Reference buildSmPre1Ref() {
 		return new DefaultReference.Builder().type(ReferenceTypes.MODEL_REFERENCE).keys(new DefaultKey.Builder().type(KeyTypes.SUBMODEL).value(SM_PRE1_ID).build()).build();
 	}
@@ -100,7 +112,16 @@ public class TestFixture {
 	}
 
 	public SubmodelDescriptor buildSmPre1Descriptor() {
-		return DummySubmodelDescriptorFactory.createDummyDescriptor(SM_PRE1_ID, SM_PRE1_IDSHORT, smRepositoryBasePath, null);
+		return DummySubmodelDescriptorFactory.createDummyDescriptor(SM_PRE1_ID, SM_PRE1_IDSHORT, null, smRepositoryBasePath);
+	}
+
+	public SubmodelDescriptor buildSmPre1Descriptor_withMultipleInterfaces() {
+		LinkedList<org.eclipse.digitaltwin.basyx.submodelregistry.client.model.Endpoint> endpoints = new LinkedList<>();
+
+		endpoints.add(DummySubmodelDescriptorFactory.createEndpoint(SM_POS1_ID, smRepositoryBasePath, "OTHER-3.0"));
+		endpoints.add(DummySubmodelDescriptorFactory.createEndpoint(SM_PRE1_ID, smRepositoryBasePath, "SUBMODEL-3.0"));
+
+		return DummySubmodelDescriptorFactory.createDummyDescriptor(SM_PRE1_ID, SM_PRE1_IDSHORT, null, endpoints);
 	}
 
 	public AssetAdministrationShell buildAasPos1() {
@@ -116,7 +137,7 @@ public class TestFixture {
 	}
 
 	public SubmodelDescriptor buildSmPos1Descriptor() {
-		return DummySubmodelDescriptorFactory.createDummyDescriptor(SM_POS1_ID, SM_POS1_IDSHORT, smRepositoryBasePath, new AttributeMapper(ConnectedAasManagerHelper.buildObjectMapper()).mapSemanticId(buildSmPos1SemanticId()));
+		return DummySubmodelDescriptorFactory.createDummyDescriptor(SM_POS1_ID, SM_POS1_IDSHORT, new AttributeMapper(ConnectedAasManagerHelper.buildObjectMapper()).mapSemanticId(buildSmPos1SemanticId()), smRepositoryBasePath);
 	}
 
 	public Reference buildSmPos1SemanticId() {

--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/resolvers/RegistryDescriptorResolverTest.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/resolvers/RegistryDescriptorResolverTest.java
@@ -31,7 +31,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 import org.eclipse.digitaltwin.basyx.aasenvironment.client.DummyAasEnvironmentComponent;
 import org.eclipse.digitaltwin.basyx.aasenvironment.client.TestFixture;
-import org.eclipse.digitaltwin.basyx.aasregistry.client.ApiException;
 import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
 import org.eclipse.digitaltwin.basyx.submodelrepository.SubmodelRepository;
 import org.junit.AfterClass;
@@ -52,10 +51,10 @@ public class RegistryDescriptorResolverTest {
 	private static AasRepository aasRepository;
 	private static SubmodelRepository smRepository;
 
-	private final static String AAS_REPOSITORY_BASE_PATH = "http://localhost:8081";
-	private final static String SM_REPOSITORY_BASE_PATH = "http://localhost:8081";
+	private static final String AAS_REPOSITORY_BASE_PATH = "http://localhost:8081";
+	private static final String SM_REPOSITORY_BASE_PATH = "http://localhost:8081";
 
-	private final static TestFixture FIXTURE = new TestFixture(AAS_REPOSITORY_BASE_PATH, SM_REPOSITORY_BASE_PATH);
+	private static final TestFixture FIXTURE = new TestFixture(AAS_REPOSITORY_BASE_PATH, SM_REPOSITORY_BASE_PATH);
 
 	@BeforeClass
 	public static void initApplication() {
@@ -65,6 +64,8 @@ public class RegistryDescriptorResolverTest {
 		smRepository = appContext.getBean(SubmodelRepository.class);
 		aasRepository.createAas(FIXTURE.buildAasPre1());
 		smRepository.createSubmodel(FIXTURE.buildSmPre1());
+		aasRepository.createAas(FIXTURE.buildAasPos1());
+		smRepository.createSubmodel(FIXTURE.buildSmPos1());
 	}
 	
 	@AfterClass
@@ -73,7 +74,7 @@ public class RegistryDescriptorResolverTest {
 	}
 
 	@Test
-	public void resolveAasDescriptor() throws ApiException {
+	public void resolveAasDescriptor() {
 		AasDescriptorResolver resolver = new AasDescriptorResolver(new EndpointResolver());
 		
 		AssetAdministrationShell expectedAas = FIXTURE.buildAasPre1();
@@ -84,7 +85,18 @@ public class RegistryDescriptorResolverTest {
 	}
 
 	@Test
-	public void resolveSmDescriptor() throws ApiException {
+	public void resolveAasDescriptor_withMultipleInterfaces() {
+		AasDescriptorResolver resolver = new AasDescriptorResolver(new EndpointResolver());
+
+		AssetAdministrationShell expectedAas = FIXTURE.buildAasPre1();
+
+		AssetAdministrationShell actualAas = resolver.resolveDescriptor(FIXTURE.buildAasPre1Descriptor_withMultipleInterfaces()).getAAS();
+
+		assertEquals(expectedAas, actualAas);
+	}
+
+	@Test
+	public void resolveSmDescriptor() {
 		SubmodelDescriptorResolver resolver = new SubmodelDescriptorResolver(new EndpointResolver());
 
 		Submodel expectedSm = FIXTURE.buildSmPre1();
@@ -94,4 +106,14 @@ public class RegistryDescriptorResolverTest {
 		assertEquals(expectedSm, actualSm);
 	}
 
+	@Test
+	public void resolveSmDescriptor_withMultipleInterfaces() {
+		SubmodelDescriptorResolver resolver = new SubmodelDescriptorResolver(new EndpointResolver());
+
+		Submodel expectedSm = FIXTURE.buildSmPre1();
+
+		Submodel actualSm = resolver.resolveDescriptor(FIXTURE.buildSmPre1Descriptor_withMultipleInterfaces()).getSubmodel();
+
+		assertEquals(expectedSm, actualSm);
+	}
 }

--- a/basyx.aasregistry/basyx.aasregistry-client-native/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/main/client/mapper/DummyAasDescriptorFactory.java
+++ b/basyx.aasregistry/basyx.aasregistry-client-native/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/main/client/mapper/DummyAasDescriptorFactory.java
@@ -27,6 +27,8 @@ package org.eclipse.digitaltwin.basyx.aasregistry.main.client.mapper;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetKind;
@@ -43,7 +45,7 @@ import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifier;
 public class DummyAasDescriptorFactory {
 	private static final String AAS_REPOSITORY_PATH = "/shells";
 
-	public static AssetAdministrationShellDescriptor createDummyDescriptor(String aasId, String idShort, String globalAssetId, String... aasRepoBaseUrls) {
+	public static AssetAdministrationShellDescriptor createDummyDescriptor(String aasId, String idShort, String globalAssetId, List<Endpoint> endpoints) {
 
 		AssetAdministrationShellDescriptor descriptor = new AssetAdministrationShellDescriptor();
 
@@ -51,15 +53,24 @@ public class DummyAasDescriptorFactory {
 		descriptor.setIdShort(idShort);
 		descriptor.setAssetKind(AssetKind.INSTANCE);
 		descriptor.setGlobalAssetId(globalAssetId);
-		for (String eachUrl : aasRepoBaseUrls) {
-			descriptor.addEndpointsItem(createEndpointItem(aasId, eachUrl));
-		}
+		descriptor.setEndpoints(endpoints);
+
 		return descriptor;
 	}
 
-	private static Endpoint createEndpointItem(String aasId, String aasRepoBaseUrl) {
+	public static AssetAdministrationShellDescriptor createDummyDescriptor(String aasId, String idShort, String globalAssetId, String... aasRepoBaseUrls) {
+		LinkedList<Endpoint> endpoints = new LinkedList<>();
+
+		for (String eachUrl : aasRepoBaseUrls) {
+			endpoints.add(createEndpoint(aasId, eachUrl, "AAS-3.0"));
+		}
+
+		return createDummyDescriptor(aasId, idShort, globalAssetId, endpoints);
+	}
+
+	public static Endpoint createEndpoint(String aasId, String aasRepoBaseUrl, String endpointInterface) {
 		Endpoint endpoint = new Endpoint();
-		endpoint.setInterface("AAS-3.0");
+		endpoint.setInterface(endpointInterface);
 		endpoint.setProtocolInformation(createProtocolInformation(aasId, aasRepoBaseUrl));
 
 		return endpoint;

--- a/basyx.submodelregistry/basyx.submodelregistry-client-native/src/test/java/org/eclipse/digitaltwin/basyx/submodelregistry/client/mapper/DummySubmodelDescriptorFactory.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-client-native/src/test/java/org/eclipse/digitaltwin/basyx/submodelregistry/client/mapper/DummySubmodelDescriptorFactory.java
@@ -28,6 +28,8 @@ package org.eclipse.digitaltwin.basyx.submodelregistry.client.mapper;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifier;
 import org.eclipse.digitaltwin.basyx.submodelregistry.client.model.Endpoint;
@@ -47,29 +49,33 @@ import org.eclipse.digitaltwin.basyx.submodelregistry.client.model.SubmodelDescr
 public class DummySubmodelDescriptorFactory {
 	private static final String SUBMODEL_REPOSITORY_PATH = "/submodels";
 
-	public static SubmodelDescriptor createDummyDescriptor(String smId, String idShort, String smRepoBaseUrl, Reference semanticId) {
-		return createDummyDescriptor(smId, idShort, new String[] {smRepoBaseUrl}, semanticId);
-	}
-	
-	public static SubmodelDescriptor createDummyDescriptor(String smId, String idShort, String[] smRepoBaseUrls, Reference semanticId) {
+	public static SubmodelDescriptor createDummyDescriptor(String smId, String idShort, Reference semanticId, List<Endpoint> endpoints) {
 		SubmodelDescriptor descriptor = new SubmodelDescriptor();
 
 		descriptor.setId(smId);
 		descriptor.setIdShort(idShort);
 		descriptor.setSemanticId(semanticId);
-		for (String eachUrl : smRepoBaseUrls) {
-			descriptor.addEndpointsItem(createEndpointItem(smId, eachUrl));
-		}
+		descriptor.setEndpoints(endpoints);
+
 		return descriptor;
+	}
+
+	public static SubmodelDescriptor createDummyDescriptor(String smId, String idShort, Reference semanticId, String... smRepoBaseUrls) {
+		LinkedList<Endpoint> endpoints = new LinkedList<>();
+		for (String eachUrl : smRepoBaseUrls) {
+			endpoints.add(createEndpoint(smId, eachUrl, "SUBMODEL-3.0"));
+		}
+
+		return createDummyDescriptor(smId, idShort, semanticId, endpoints);
 	}
 
 	public static Reference createSemanticId() {
 		return new Reference().keys(Arrays.asList(new Key().type(KeyTypes.GLOBALREFERENCE).value("0173-1#01-AFZ615#016"))).type(ReferenceTypes.EXTERNALREFERENCE);
 	}
 
-	private static Endpoint createEndpointItem(String smId, String smRepoBaseUrl) {
+	public static Endpoint createEndpoint(String smId, String smRepoBaseUrl, String endpointInterface) {
 		Endpoint endpoint = new Endpoint();
-		endpoint.setInterface("SUBMODEL-3.0");
+		endpoint.setInterface(endpointInterface);
 		endpoint.setProtocolInformation(createProtocolInformation(smId, smRepoBaseUrl));
 
 		return endpoint;

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/SubmodelRepositoryRegistryLinkTestSuite.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/SubmodelRepositoryRegistryLinkTestSuite.java
@@ -64,7 +64,7 @@ public abstract class SubmodelRepositoryRegistryLinkTestSuite {
 	protected abstract String getSubmodelRegistryUrl(); 
 	protected abstract SubmodelRegistryApi getSubmodelRegistryApi();
 
-	private final SubmodelDescriptor DUMMY_DESCRIPTOR = DummySubmodelDescriptorFactory.createDummyDescriptor(DUMMY_SUBMODEL_ID, DUMMY_SUBMODEL_IDSHORT, getSubmodelRepoBaseUrls(), DummySubmodelDescriptorFactory.createSemanticId());
+	private final SubmodelDescriptor DUMMY_DESCRIPTOR = DummySubmodelDescriptorFactory.createDummyDescriptor(DUMMY_SUBMODEL_ID, DUMMY_SUBMODEL_IDSHORT, DummySubmodelDescriptorFactory.createSemanticId(), getSubmodelRepoBaseUrls());
 	
 	@Test
 	public void createSubmodel() throws FileNotFoundException, IOException, ApiException {


### PR DESCRIPTION
## Description of Changes

This PR changes the endpoint resolve strategy from client lib to only match the endpoint with the correct interface (see related issue).

## Related Issue

Closes #499 
