### PR TITLE
Add submodelReference eventing to MqttAasRepository PR

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/Readme.md
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/Readme.md
@@ -6,3 +6,5 @@ This feature provides hierarchical MQTT eventing for a multitude of events:
 | AAS Created | aas-repository/\$repoId/shells/created| Created AAS JSON |
 | AAS Updated   | aas-repository/\$repoId/shells/updated| Updated AAS JSON|
 | AAS Deleted   | aas-repository/\$repoId/shells/deleted| Deleted AAS JSON|
+| Submodel Reference Created | aas-repository/\$repoId/shells/submodels/\$submodelId/created| Created AAS JSON |
+| Submodel Reference Deleted   | aas-repository/\$repoId/shells/submodels/\$submodelId/deleted| Deleted AAS JSON|

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2021 the Eclipse BaSyx Authors
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepository.java
@@ -107,12 +107,19 @@ public class MqttAasRepository implements AasRepository {
 
 	@Override
 	public void addSubmodelReference(String aasId, Reference submodelReference) {
+		AssetAdministrationShell shell = decorated.getAas(aasId);
 		decorated.addSubmodelReference(aasId, submodelReference);
+		
+		String referenceId = submodelReference.getKeys().get(0).getValue();
+		
+		submodelReferenceCreated(shell, getName(), referenceId);
 	}
 
 	@Override
 	public void removeSubmodelReference(String aasId, String submodelId) {
+		AssetAdministrationShell shell = decorated.getAas(aasId);
 		decorated.removeSubmodelReference(aasId, submodelId);
+		submodelReferenceDeleted(shell, getName(), submodelId);
 	}
 
 	@Override
@@ -135,6 +142,14 @@ public class MqttAasRepository implements AasRepository {
 
 	private void aasDeleted(AssetAdministrationShell shell, String repoId) {
 		sendMqttMessage(topicFactory.createDeleteAASTopic(repoId), serializePayload(shell));
+	}
+	
+	private void submodelReferenceCreated(AssetAdministrationShell shell, String repoId, String referenceId) {
+		sendMqttMessage(topicFactory.createCreateAASSubmodelReferenceTopic(repoId, referenceId), serializePayload(shell));
+	}
+
+	private void submodelReferenceDeleted(AssetAdministrationShell shell, String repoId, String referenceId) {
+		sendMqttMessage(topicFactory.createDeleteAASSubmodelReferenceTopic(repoId, referenceId), serializePayload(shell));
 	}
 
 	private String serializePayload(AssetAdministrationShell shell) {

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepositoryTopicFactory.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepositoryTopicFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2021 the Eclipse BaSyx Authors
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
  * 
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepositoryTopicFactory.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepositoryTopicFactory.java
@@ -37,6 +37,7 @@ import org.eclipse.digitaltwin.basyx.common.mqttcore.encoding.Encoder;
 public class MqttAasRepositoryTopicFactory extends AbstractMqttTopicFactory {
 	private static final String AASREPOSITORY = "aas-repository";
 	private static final String SHELLS = "shells";
+	private static final String SUBMODELS = "submodels";
 	private static final String CREATED = "created";
 	private static final String UPDATED = "updated";
 	private static final String DELETED = "deleted";
@@ -90,6 +91,42 @@ public class MqttAasRepositoryTopicFactory extends AbstractMqttTopicFactory {
 				.add(AASREPOSITORY)
 				.add(repoId)
 				.add(SHELLS)
+				.add(DELETED)
+				.toString();
+	}
+	
+	/**
+	 * Creates the hierarchical topic for the submodel reference create event
+	 * 
+	 * @param repoId
+	 * @param referenceId
+	 * @return
+	 */
+	public String createCreateAASSubmodelReferenceTopic(String repoId, String referenceId) {
+		return new StringJoiner("/", "", "")
+				.add(AASREPOSITORY)
+				.add(repoId)
+				.add(SHELLS)
+				.add(SUBMODELS)
+				.add(referenceId)
+				.add(CREATED)
+				.toString();
+	}
+	
+	/**
+	 * Creates the hierarchical topic for the submodel reference delete event
+	 * 
+	 * @param repoId
+	 * @param referenceId
+	 * @return
+	 */
+	public String createDeleteAASSubmodelReferenceTopic(String repoId, String referenceId) {
+		return new StringJoiner("/", "", "")
+				.add(AASREPOSITORY)
+				.add(repoId)
+				.add(SHELLS)
+				.add(SUBMODELS)
+				.add(referenceId)
 				.add(DELETED)
 				.toString();
 	}

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/TestMqttV2AASAggregatorObserver.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/TestMqttV2AASAggregatorObserver.java
@@ -1,7 +1,5 @@
-package org.eclipse.digitaltwin.basyx.aasrepository.feature.mqtt;
-
 /*******************************************************************************
- * Copyright (C) 2021 the Eclipse BaSyx Authors
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -24,6 +22,7 @@ package org.eclipse.digitaltwin.basyx.aasrepository.feature.mqtt;
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
+package org.eclipse.digitaltwin.basyx.aasrepository.feature.mqtt;
 
 import static org.junit.Assert.assertEquals;
 

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/TestMqttV2AASAggregatorObserver.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/TestMqttV2AASAggregatorObserver.java
@@ -95,8 +95,6 @@ public class TestMqttV2AASAggregatorObserver {
 	public void createAasEvent() throws DeserializationException {
 		AssetAdministrationShell shell = createAasDummy("createAasEventId");
 		aasRepository.createAas(shell);
-
-		String lastTopic = listener.lastTopic;
 		
 		assertEquals(topicFactory.createCreateAASTopic(aasRepository.getName()), listener.lastTopic);
 		assertEquals(shell, deserializePayload(listener.lastPayload));


### PR DESCRIPTION
Added event triggers when adding or removing SubmodelReferences using the AasEnvironment MQTT feature.

Updated README contains the newly added events.

Closes #427