### PR TITLE
Add proxy build argument to dockerfiles

### DIFF
--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice.component/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
+++ b/basyx.aasenvironment/basyx.aasenvironment.component/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mem/src/main/docker/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM eclipse-temurin:17 as builder
 ARG HTTP_PROXY
-ARG HTTPS_PROXYCOPY maven/${project.build.finalName}.jar ./
+ARG HTTPS_PROXY
+COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17

--- a/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,11 @@
 FROM eclipse-temurin:17 as builder
-COPY maven/${project.build.finalName}.jar ./
+ARG HTTP_PROXY
+ARG HTTPS_PROXYCOPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mem/src/main/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/src/main/docker/Dockerfile
+++ b/basyx.aasregistry/basyx.aasregistry-service-release-log-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
+++ b/basyx.aasrepository/basyx.aasrepository.component/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
+++ b/basyx.aasxfileserver/basyx.aasxfileserver.component/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
+++ b/basyx.conceptdescriptionrepository/basyx.conceptdescriptionrepository.component/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mem/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mem/src/main/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-kafka-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mem/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mem/src/main/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mongodb/src/main/docker/Dockerfile
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-release-log-mongodb/src/main/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM eclipse-temurin:17 as builder
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY maven/${project.build.finalName}.jar ./
 RUN java -Djarmode=layertools -jar ${project.build.finalName}.jar extract
 
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN mkdir /workspace
 WORKDIR /workspace
 COPY --from=builder dependencies/ ./

--- a/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
+++ b/basyx.submodelrepository/basyx.submodelrepository.component/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/basyx.submodelservice/basyx.submodelservice.example/Dockerfile
+++ b/basyx.submodelservice/basyx.submodelservice.example/Dockerfile
@@ -1,4 +1,6 @@
 FROM eclipse-temurin:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 USER nobody
 WORKDIR /application
 ARG JAR_FILE=target/*-exec.jar

--- a/ci/keycloak/Dockerfile
+++ b/ci/keycloak/Dockerfile
@@ -1,5 +1,6 @@
 FROM quay.io/keycloak/keycloak:22.0.0
-
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 # Make the realm configuration available for import
 COPY /realm/BaSyx-realm.json /opt/keycloak_import/
 

--- a/ci/keycloak/Dockerfile.keycloak
+++ b/ci/keycloak/Dockerfile.keycloak
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM maven:3-eclipse-temurin-17-alpine as build
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /workspace
 COPY ./initializer/pom.xml /workspace/pom.xml
 COPY ./initializer/src /workspace/src
@@ -7,6 +9,8 @@ COPY ./realm/BaSyx-realm.json /workspace/BaSyx-realm.json
 RUN mvn install
 
 FROM keycloak/keycloak:24.0.4
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY --from=build /workspace/target/org.eclipse.digitaltwin.basyx.v3.clients-keycloak-issuer-initializer.jar /opt/keycloak/providers/issuer-initializer.jar
 COPY --from=build /workspace/BaSyx-realm.json /opt/keycloak/data/import/BaSyx-realm.json
 

--- a/examples/BaSyxClient/basyx-client/Dockerfile
+++ b/examples/BaSyxClient/basyx-client/Dockerfile
@@ -1,10 +1,14 @@
 FROM maven:3.8.1-openjdk-17 AS build
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /app
 COPY pom.xml .
 COPY src src
 RUN mvn clean package -DskipTests
 
 FROM openjdk:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /app
 COPY --from=build /app/target/*-jar-with-dependencies.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/BaSyxClient/legacy-erp/Dockerfile
+++ b/examples/BaSyxClient/legacy-erp/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.10-slim
-
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /app
 
 COPY . /app

--- a/examples/BaSyxDatabridge/mqtt-publisher/Dockerfile
+++ b/examples/BaSyxDatabridge/mqtt-publisher/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim
-
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 RUN pip install paho-mqtt
 
 COPY publisher.py /publisher.py

--- a/examples/BaSyxOperationDelegation/exampleOperationService/Dockerfile
+++ b/examples/BaSyxOperationDelegation/exampleOperationService/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: Build Stage
 FROM maven:3.8.1-openjdk-17 AS build
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /app
 # Kopiere die pom.xml und lade die Abhängigkeiten herunter
 COPY pom.xml .
@@ -11,6 +13,8 @@ RUN mvn clean package -DskipTests
 
 # Stage 2: Runtime Stage
 FROM openjdk:17
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080

--- a/examples/BaSyxSecured/keycloak/Dockerfile
+++ b/examples/BaSyxSecured/keycloak/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM maven:3-eclipse-temurin-17 AS build
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 WORKDIR /workspace
 COPY ./initializer/pom.xml /workspace/pom.xml
 COPY ./initializer/src /workspace/src


### PR DESCRIPTION
## Description of Changes

As a user within a corporate network (behind a proxy server), I also want to build Docker images.

This PR adds build arguments to all Dockerfiles to specify a proxy server.
The user can easily set the proxy server via shell ENV variables, e.g. in Powershell with`$ENV:HTTPS_PROXY='http://proxyserver:port'` and `$ENV:HTTP_PROXY='http://proxyserver:port'`

This PR does not affecting the Docker images builds if the corresponding ENV variables are not set.

Compare https://github.com/eclipse-basyx/basyx-aas-web-ui/pull/84