### PR TITLE
Fix issue with the parallel execution of the `ConnectedAasManager::createSubmodelInAas` method.

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/ConnectedAasManagerHelper.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/ConnectedAasManagerHelper.java
@@ -60,13 +60,13 @@ class ConnectedAasManagerHelper {
 	static AasDescriptorFactory buildAasDescriptorFactory(String... aasRepositoryBaseUrls) {
 		AttributeMapper attributeMapper = new AttributeMapper(objectMapper);
 
-		return new AasDescriptorFactory(null, List.of(aasRepositoryBaseUrls), attributeMapper);
+		return new AasDescriptorFactory(List.of(aasRepositoryBaseUrls), attributeMapper);
 	}
 
 	static SubmodelDescriptorFactory buildSmDescriptorFactory(String... aasRepositoryBaseUrls) {
 		org.eclipse.digitaltwin.basyx.submodelregistry.client.mapper.AttributeMapper attributeMapperSm = new org.eclipse.digitaltwin.basyx.submodelregistry.client.mapper.AttributeMapper(
 				objectMapper);
-		return new SubmodelDescriptorFactory(null, List.of(aasRepositoryBaseUrls), attributeMapperSm);
+		return new SubmodelDescriptorFactory(List.of(aasRepositoryBaseUrls), attributeMapperSm);
 	}
 
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/TestConnectedAasManagerMultithreading.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/TestConnectedAasManagerMultithreading.java
@@ -1,3 +1,28 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
 package org.eclipse.digitaltwin.basyx.aasenvironment.client;
 
 import static org.junit.Assert.assertEquals;

--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/TestConnectedAasManagerMultithreading.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/TestConnectedAasManagerMultithreading.java
@@ -1,0 +1,126 @@
+package org.eclipse.digitaltwin.basyx.aasenvironment.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.api.RegistryAndDiscoveryInterfaceApi;
+import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
+import org.eclipse.digitaltwin.basyx.aasrepository.client.ConnectedAasRepository;
+import org.eclipse.digitaltwin.basyx.submodelregistry.client.api.SubmodelRegistryApi;
+import org.eclipse.digitaltwin.basyx.submodelrepository.SubmodelRepository;
+import org.eclipse.digitaltwin.basyx.submodelrepository.client.ConnectedSubmodelRepository;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class TestConnectedAasManagerMultithreading {
+    static final String AAS_REPOSITORY_BASE_PATH = "http://localhost:8081";
+    static final String SM_REPOSITORY_BASE_PATH = "http://localhost:8081";
+    static final String AAS_REGISTRY_BASE_PATH = "http://localhost:8050";
+    static final String SM_REGISTRY_BASE_PATH = "http://localhost:8060";
+    static final int N_THREADS = 20;
+
+    static ConfigurableApplicationContext appContext;
+    static AasRepository aasRepository;
+    static SubmodelRepository smRepository;
+
+    static ConnectedAasRepository connectedAasRepository;
+    static ConnectedSubmodelRepository connectedSmRepository;
+    static RegistryAndDiscoveryInterfaceApi aasRegistryApi;
+    static SubmodelRegistryApi smRegistryApi;
+
+    static ConnectedAasManager aasManager;
+
+    @BeforeClass
+    public static void setupRepositories() {
+        appContext = new SpringApplication(DummyAasEnvironmentComponent.class).run(new String[] {});
+
+        connectedAasRepository = new ConnectedAasRepository(AAS_REPOSITORY_BASE_PATH);
+        connectedSmRepository = new ConnectedSubmodelRepository(SM_REPOSITORY_BASE_PATH);
+        aasRegistryApi = new RegistryAndDiscoveryInterfaceApi(AAS_REGISTRY_BASE_PATH);
+        smRegistryApi = new SubmodelRegistryApi(SM_REGISTRY_BASE_PATH);
+        aasManager = new ConnectedAasManager(AAS_REGISTRY_BASE_PATH, AAS_REPOSITORY_BASE_PATH, SM_REGISTRY_BASE_PATH, SM_REPOSITORY_BASE_PATH);
+
+        cleanUpRegistries();
+    }
+
+    @After
+    public void cleanUpComponents() {
+        cleanUpRegistries();
+    }
+
+    @AfterClass
+    public static void stopContext() {
+        appContext.close();
+    }
+
+    @Test
+    public void testParallelSubmodelCreation() throws ExecutionException, InterruptedException {
+        AssetAdministrationShell shell = createShell();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(N_THREADS);
+        ConcurrentLinkedDeque<String> createdSubmodelIds = new ConcurrentLinkedDeque<>();
+
+        List<Future<Boolean>> futures = IntStream.range(0, N_THREADS).mapToObj(i -> executorService.submit(() -> createdSubmodelIds.add(createSubmodel(shell.getId(), i)))).toList();
+
+        try {
+            for (int i = 0; i < N_THREADS; i++) {
+                futures.get(i).get();
+            }
+        } finally {
+            executorService.shutdown();
+        }
+
+        createdSubmodelIds.forEach(TestConnectedAasManagerMultithreading::assertSubmodelExists);
+    }
+
+    static void assertSubmodelExists(String submodelId) {
+        assertEquals(submodelId, aasManager.getSubmodelService(submodelId).getSubmodel().getId());
+    }
+
+    private static void cleanUpRegistries() {
+        try {
+            aasRegistryApi.deleteAllShellDescriptors();
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+        try {
+            smRegistryApi.deleteAllSubmodelDescriptors();
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    private static AssetAdministrationShell createShell() {
+        String id = UUID.randomUUID().toString();
+        DefaultAssetAdministrationShell shell = new DefaultAssetAdministrationShell.Builder().id(id).build();
+        aasManager.createAas(shell);
+        return aasManager.getAasService(id).getAAS();
+    }
+
+    private static String createSubmodel(String aasId, int threadId) {
+        try {
+            String id = aasId + "-thread" + threadId;
+            DefaultSubmodel submodel = new DefaultSubmodel.Builder().id(id).build();
+            aasManager.createSubmodelInAas(aasId, submodel);
+            return id;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed at thread " + threadId, e);
+        }
+    }
+
+}

--- a/basyx.aasregistry/basyx.aasregistry-client-native/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/main/client/factory/AasDescriptorFactory.java
+++ b/basyx.aasregistry/basyx.aasregistry-client-native/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/main/client/factory/AasDescriptorFactory.java
@@ -53,15 +53,12 @@ public class AasDescriptorFactory {
 	private static final String AAS_INTERFACE = "AAS-3.0";
 	private static final String AAS_REPOSITORY_PATH = "shells";
 
-	private AssetAdministrationShell shell;
-	private List<String> aasRepositoryURLs;
+	private final List<String> aasRepositoryURLs;
+	private static AttributeMapper attributeMapper;
 
-	private AttributeMapper attributeMapper;
-
-	public AasDescriptorFactory(AssetAdministrationShell shell, List<String> aasRepositoryBaseURLs, AttributeMapper attributeMapper) {
-		this.shell = shell;
+	public AasDescriptorFactory(List<String> aasRepositoryBaseURLs, AttributeMapper attributeMapper) {
 		this.aasRepositoryURLs = createAasRepositoryUrls(aasRepositoryBaseURLs);
-		this.attributeMapper = attributeMapper;
+		AasDescriptorFactory.attributeMapper = attributeMapper;
 	}
 
 	/**
@@ -69,7 +66,7 @@ public class AasDescriptorFactory {
 	 * 
 	 * @return the created AssetAdministrationShellDescriptor
 	 */
-	public AssetAdministrationShellDescriptor create() {
+	public AssetAdministrationShellDescriptor create(AssetAdministrationShell shell) {
 
 		AssetAdministrationShellDescriptor descriptor = new AssetAdministrationShellDescriptor();
 
@@ -77,7 +74,7 @@ public class AasDescriptorFactory {
 
 		setIdShort(shell.getIdShort(), descriptor);
 
-		setEndpointItem(shell.getId(), descriptor);
+		setEndpointItem(shell.getId(), descriptor, aasRepositoryURLs);
 
 		setDescription(shell.getDescription(), descriptor);
 
@@ -96,12 +93,7 @@ public class AasDescriptorFactory {
 		return descriptor;
 	}
 
-	public AssetAdministrationShellDescriptor create(AssetAdministrationShell shell) {
-		this.shell = shell;
-		return create();
-	}
-
-	private void setDescription(List<LangStringTextType> descriptions, AssetAdministrationShellDescriptor descriptor) {
+	private static void setDescription(List<LangStringTextType> descriptions, AssetAdministrationShellDescriptor descriptor) {
 
 		if (descriptions == null || descriptions.isEmpty())
 			return;
@@ -109,7 +101,7 @@ public class AasDescriptorFactory {
 		descriptor.setDescription(attributeMapper.mapDescription(descriptions));
 	}
 
-	private void setDisplayName(List<LangStringNameType> displayNames, AssetAdministrationShellDescriptor descriptor) {
+	private static void setDisplayName(List<LangStringNameType> displayNames, AssetAdministrationShellDescriptor descriptor) {
 
 		if (displayNames == null || displayNames.isEmpty())
 			return;
@@ -117,7 +109,7 @@ public class AasDescriptorFactory {
 		descriptor.setDisplayName(attributeMapper.mapDisplayName(displayNames));
 	}
 
-	private void setExtensions(List<Extension> extensions, AssetAdministrationShellDescriptor descriptor) {
+	private static void setExtensions(List<Extension> extensions, AssetAdministrationShellDescriptor descriptor) {
 
 		if (extensions == null || extensions.isEmpty())
 			return;
@@ -125,7 +117,7 @@ public class AasDescriptorFactory {
 		descriptor.setExtensions(attributeMapper.mapExtensions(extensions));
 	}
 
-	private void setAdministration(AdministrativeInformation administration, AssetAdministrationShellDescriptor descriptor) {
+	private static void setAdministration(AdministrativeInformation administration, AssetAdministrationShellDescriptor descriptor) {
 
 		if (administration == null)
 			return;
@@ -133,7 +125,7 @@ public class AasDescriptorFactory {
 		descriptor.setAdministration(attributeMapper.mapAdministration(administration));
 	}
 
-	private void setAssetKind(AssetInformation assetInformation, AssetAdministrationShellDescriptor descriptor) {
+	private static void setAssetKind(AssetInformation assetInformation, AssetAdministrationShellDescriptor descriptor) {
 
 		if (assetInformation == null || assetInformation.getAssetKind() == null)
 			return;
@@ -141,7 +133,7 @@ public class AasDescriptorFactory {
 		descriptor.setAssetKind(attributeMapper.mapAssetKind(assetInformation.getAssetKind()));
 	}
 
-	private void setAssetType(AssetInformation assetInformation, AssetAdministrationShellDescriptor descriptor) {
+	private static void setAssetType(AssetInformation assetInformation, AssetAdministrationShellDescriptor descriptor) {
 
 		if (assetInformation == null || assetInformation.getAssetType() == null)
 			return;
@@ -149,7 +141,7 @@ public class AasDescriptorFactory {
 		descriptor.setAssetType(assetInformation.getAssetType());
 	}
 
-	private void setGlobalAssetId(AssetInformation assetInformation, AssetAdministrationShellDescriptor descriptor) {
+	private static void setGlobalAssetId(AssetInformation assetInformation, AssetAdministrationShellDescriptor descriptor) {
 
 		if (assetInformation == null || assetInformation.getGlobalAssetId() == null)
 			return;
@@ -157,7 +149,7 @@ public class AasDescriptorFactory {
 		descriptor.setGlobalAssetId(assetInformation.getGlobalAssetId());
 	}
 
-	private void setEndpointItem(String shellId, AssetAdministrationShellDescriptor descriptor) {
+	private static void setEndpointItem(String shellId, AssetAdministrationShellDescriptor descriptor, List<String> aasRepositoryURLs) {
 		for (String eachUrl : aasRepositoryURLs) {
 			Endpoint endpoint = new Endpoint();
 			endpoint.setInterface(AAS_INTERFACE);
@@ -168,7 +160,7 @@ public class AasDescriptorFactory {
 		}
 	}
 
-	private ProtocolInformation createProtocolInformation(String shellId, String url) {
+	private static ProtocolInformation createProtocolInformation(String shellId, String url) {
 		String href = String.format("%s/%s", url, Base64UrlEncodedIdentifier.encodeIdentifier(shellId));
 
 		ProtocolInformation protocolInformation = new ProtocolInformation();
@@ -178,15 +170,15 @@ public class AasDescriptorFactory {
 		return protocolInformation;
 	}
 
-	private void setIdShort(String idShort, AssetAdministrationShellDescriptor descriptor) {
+	private static void setIdShort(String idShort, AssetAdministrationShellDescriptor descriptor) {
 		descriptor.setIdShort(idShort);
 	}
 
-	private void setId(String shellId, AssetAdministrationShellDescriptor descriptor) {
+	private static void setId(String shellId, AssetAdministrationShellDescriptor descriptor) {
 		descriptor.setId(shellId);
 	}
 
-	private String getProtocol(String endpoint) {
+	private static String getProtocol(String endpoint) {
 		try {
 			return new URL(endpoint).getProtocol();
 		} catch (MalformedURLException e) {
@@ -194,7 +186,7 @@ public class AasDescriptorFactory {
 		}
 	}
 
-	private List<String> createAasRepositoryUrls(List<String> aasRepositoryBaseURLs) {
+	private static List<String> createAasRepositoryUrls(List<String> aasRepositoryBaseURLs) {
 		List<String> toReturn = new ArrayList<>(aasRepositoryBaseURLs.size());
 		for (String eachUrl : aasRepositoryBaseURLs) {
 			toReturn.add(RepositoryUrlHelper.createRepositoryUrl(eachUrl, AAS_REPOSITORY_PATH));

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
@@ -78,7 +78,7 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	@Override
 	public void createAas(AssetAdministrationShell shell) throws CollidingIdentifierException {
-		AssetAdministrationShellDescriptor descriptor = new AasDescriptorFactory(shell, aasRepositoryRegistryLink.getAasRepositoryBaseURLs(), attributeMapper).create();
+		AssetAdministrationShellDescriptor descriptor = new AasDescriptorFactory(aasRepositoryRegistryLink.getAasRepositoryBaseURLs(), attributeMapper).create(shell);
 
 		decorated.createAas(shell);
 

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/AasRepositoryRegistryLinkDescriptorGenerationTest.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/AasRepositoryRegistryLinkDescriptorGenerationTest.java
@@ -103,8 +103,8 @@ public class AasRepositoryRegistryLinkDescriptorGenerationTest {
     private AssetAdministrationShellDescriptor createAndRetrieveDescriptor(AssetAdministrationShell shell) {
         registryIntegrationAasRepository.createAas(shell);
 
-        AasDescriptorFactory descriptorFactory = new AasDescriptorFactory(shell, mockedRegistryLink.getAasRepositoryBaseURLs(), mockedAttributeMapper);
-        return descriptorFactory.create();
+        AasDescriptorFactory descriptorFactory = new AasDescriptorFactory(mockedRegistryLink.getAasRepositoryBaseURLs(), mockedAttributeMapper);
+        return descriptorFactory.create(shell);
     }
     
     private AssetAdministrationShell createDummyAas() {

--- a/basyx.aasservice/basyx.aasservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/InMemoryAasService.java
+++ b/basyx.aasservice/basyx.aasservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/InMemoryAasService.java
@@ -93,16 +93,19 @@ public class InMemoryAasService implements AasService {
 
 	@Override
 	public void addSubmodelReference(Reference submodelReference) {
-		throwExceptionIfReferenceIsAlreadyPresent(submodelReference);
-
-		aas.getSubmodels().add(submodelReference);
+		List<Reference> submodelsRefs = aas.getSubmodels();
+		synchronized (submodelsRefs) {
+			throwExceptionIfReferenceIsAlreadyPresent(submodelReference);
+			submodelsRefs.add(submodelReference);
+		}
 	}
 
 	@Override
 	public void removeSubmodelReference(String submodelId) {
-		Reference specificSubmodelReference = getSubmodelReferenceById(submodelId);
-
-		aas.getSubmodels().remove(specificSubmodelReference);
+		List<Reference> submodelsRefs = aas.getSubmodels();
+		synchronized (submodelsRefs) {
+			submodelsRefs.remove(getSubmodelReferenceById(submodelId));
+		}
 	}
 
 	@Override

--- a/basyx.submodelregistry/basyx.submodelregistry-client-native/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/client/factory/SubmodelDescriptorFactory.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-client-native/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/client/factory/SubmodelDescriptorFactory.java
@@ -53,15 +53,12 @@ public class SubmodelDescriptorFactory {
 	private static final String SUBMODEL_INTERFACE = "SUBMODEL-3.0";
 	private static final String SUBMODEL_REPOSITORY_PATH = "submodels";
 
-	private Submodel submodel;
-	private List<String> submodelRepositoryURLs;
+	private final List<String> submodelRepositoryURLs;
+	private static AttributeMapper attributeMapper;
 
-	private AttributeMapper attributeMapper;
-
-	public SubmodelDescriptorFactory(Submodel submodel, List<String> submodelRepositoryBaseURLs, AttributeMapper attributeMapper) {
-		this.submodel = submodel;
+	public SubmodelDescriptorFactory(List<String> submodelRepositoryBaseURLs, AttributeMapper attributeMapper) {
 		this.submodelRepositoryURLs = createSubmodelRepositoryUrls(submodelRepositoryBaseURLs);
-		this.attributeMapper = attributeMapper;
+		SubmodelDescriptorFactory.attributeMapper = attributeMapper;
 	}
 
 	/**
@@ -69,7 +66,7 @@ public class SubmodelDescriptorFactory {
 	 * 
 	 * @return the created {@link SubmodelDescriptor}
 	 */
-	public SubmodelDescriptor create() {
+	public SubmodelDescriptor create(Submodel submodel) {
 
 		SubmodelDescriptor descriptor = new SubmodelDescriptor();
 
@@ -77,7 +74,7 @@ public class SubmodelDescriptorFactory {
 
 		setIdShort(submodel.getIdShort(), descriptor);
 
-		setEndpointItem(submodel.getId(), descriptor);
+		setEndpointItem(submodel.getId(), descriptor, submodelRepositoryURLs);
 
 		setDescription(submodel.getDescription(), descriptor);
 
@@ -94,12 +91,7 @@ public class SubmodelDescriptorFactory {
 		return descriptor;
 	}
 
-	public SubmodelDescriptor create(Submodel submodel) {
-		this.submodel = submodel;
-		return create();
-	}
-
-	private void setDescription(List<LangStringTextType> descriptions, SubmodelDescriptor descriptor) {
+	private static void setDescription(List<LangStringTextType> descriptions, SubmodelDescriptor descriptor) {
 
 		if (descriptions == null || descriptions.isEmpty())
 			return;
@@ -107,7 +99,7 @@ public class SubmodelDescriptorFactory {
 		descriptor.setDescription(attributeMapper.mapDescription(descriptions));
 	}
 
-	private void setDisplayName(List<LangStringNameType> displayNames, SubmodelDescriptor descriptor) {
+	private static void setDisplayName(List<LangStringNameType> displayNames, SubmodelDescriptor descriptor) {
 
 		if (displayNames == null || displayNames.isEmpty())
 			return;
@@ -115,7 +107,7 @@ public class SubmodelDescriptorFactory {
 		descriptor.setDisplayName(attributeMapper.mapDisplayName(displayNames));
 	}
 
-	private void setExtensions(List<Extension> extensions, SubmodelDescriptor descriptor) {
+	private static void setExtensions(List<Extension> extensions, SubmodelDescriptor descriptor) {
 
 		if (extensions == null || extensions.isEmpty())
 			return;
@@ -123,7 +115,7 @@ public class SubmodelDescriptorFactory {
 		descriptor.setExtensions(attributeMapper.mapExtensions(extensions));
 	}
 
-	private void setAdministration(AdministrativeInformation administration, SubmodelDescriptor descriptor) {
+	private static void setAdministration(AdministrativeInformation administration, SubmodelDescriptor descriptor) {
 
 		if (administration == null)
 			return;
@@ -131,7 +123,7 @@ public class SubmodelDescriptorFactory {
 		descriptor.setAdministration(attributeMapper.mapAdministration(administration));
 	}
 
-	private void setSemanticId(Reference reference, SubmodelDescriptor descriptor) {
+	private static void setSemanticId(Reference reference, SubmodelDescriptor descriptor) {
 
 		if (reference == null)
 			return;
@@ -139,7 +131,7 @@ public class SubmodelDescriptorFactory {
 		descriptor.setSemanticId(attributeMapper.mapSemanticId(reference));
 	}
 
-	private void setSupplementalSemanticId(List<Reference> supplementalSemanticIds, SubmodelDescriptor descriptor) {
+	private static void setSupplementalSemanticId(List<Reference> supplementalSemanticIds, SubmodelDescriptor descriptor) {
 
 		if (supplementalSemanticIds == null || supplementalSemanticIds.isEmpty())
 			return;
@@ -147,7 +139,7 @@ public class SubmodelDescriptorFactory {
 		descriptor.setSupplementalSemanticId(attributeMapper.mapSupplementalSemanticId(supplementalSemanticIds));
 	}
 
-	private void setEndpointItem(String shellId, SubmodelDescriptor descriptor) {
+	private static void setEndpointItem(String shellId, SubmodelDescriptor descriptor, List<String> submodelRepositoryURLs) {
 
 		for (String eachUrl : submodelRepositoryURLs) {
 			Endpoint endpoint = new Endpoint();
@@ -159,7 +151,7 @@ public class SubmodelDescriptorFactory {
 		}
 	}
 
-	private ProtocolInformation createProtocolInformation(String shellId, String url) {
+	private static ProtocolInformation createProtocolInformation(String shellId, String url) {
 		String href = String.format("%s/%s", url, Base64UrlEncodedIdentifier.encodeIdentifier(shellId));
 
 		ProtocolInformation protocolInformation = new ProtocolInformation();
@@ -169,15 +161,15 @@ public class SubmodelDescriptorFactory {
 		return protocolInformation;
 	}
 
-	private void setIdShort(String idShort, SubmodelDescriptor descriptor) {
+	private static void setIdShort(String idShort, SubmodelDescriptor descriptor) {
 		descriptor.setIdShort(idShort);
 	}
 
-	private void setId(String shellId, SubmodelDescriptor descriptor) {
+	private static void setId(String shellId, SubmodelDescriptor descriptor) {
 		descriptor.setId(shellId);
 	}
 
-	private String getProtocol(String endpoint) {
+	private static String getProtocol(String endpoint) {
 		try {
 			return new URL(endpoint).getProtocol();
 		} catch (MalformedURLException e) {
@@ -185,7 +177,7 @@ public class SubmodelDescriptorFactory {
 		}
 	}
 
-	private List<String> createSubmodelRepositoryUrls(List<String> submodelRepositoryBaseURLs) {
+	private static List<String> createSubmodelRepositoryUrls(List<String> submodelRepositoryBaseURLs) {
 		List<String> toReturn = new ArrayList<>(submodelRepositoryBaseURLs.size());
 		for (String eachUrl : submodelRepositoryBaseURLs) {
 			toReturn.add(RepositoryUrlHelper.createRepositoryUrl(eachUrl, SUBMODEL_REPOSITORY_PATH));

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
@@ -91,7 +91,7 @@ public class RegistryIntegrationSubmodelRepository implements SubmodelRepository
 
 	@Override
 	public void createSubmodel(Submodel submodel) throws CollidingIdentifierException {
-		SubmodelDescriptor descriptor = new SubmodelDescriptorFactory(submodel, submodelRepositoryRegistryLink.getSubmodelRepositoryBaseURLs(), attributeMapper).create();
+		SubmodelDescriptor descriptor = new SubmodelDescriptorFactory(submodelRepositoryRegistryLink.getSubmodelRepositoryBaseURLs(), attributeMapper).create(submodel);
 
 		decorated.createSubmodel(submodel);
 

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/SubmodelRepositoryRegistryLinkDescriptorGenerationTest.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/SubmodelRepositoryRegistryLinkDescriptorGenerationTest.java
@@ -104,8 +104,8 @@ public class SubmodelRepositoryRegistryLinkDescriptorGenerationTest {
     private SubmodelDescriptor createAndRetrieveDescriptor(Submodel submodel) throws ApiException {
         registryIntegrationSubmodelRepository.createSubmodel(submodel);
 
-        SubmodelDescriptorFactory descriptorFactory = new SubmodelDescriptorFactory(submodel, mockedRegistryLink.getSubmodelRepositoryBaseURLs(), mockedAttributeMapper);
-        return descriptorFactory.create();
+        SubmodelDescriptorFactory descriptorFactory = new SubmodelDescriptorFactory(mockedRegistryLink.getSubmodelRepositoryBaseURLs(), mockedAttributeMapper);
+        return descriptorFactory.create(submodel);
     }
     
     private Submodel createDummySubmodel() {

--- a/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelService.java
@@ -73,6 +73,8 @@ public class InMemorySubmodelService implements SubmodelService {
 
 	private final FileRepository fileRepository;
 
+	private final Object submodelLock = new Object();
+
 	/**
 	 * Creates the InMemory SubmodelService containing the passed Submodel
 	 * 
@@ -115,20 +117,21 @@ public class InMemorySubmodelService implements SubmodelService {
 	@SuppressWarnings("unchecked")
 	@Override
 	public void setSubmodelElementValue(String idShort, SubmodelElementValue value) throws ElementDoesNotExistException {
-		SubmodelElementValueMapperFactory submodelElementValueFactory = new SubmodelElementValueMapperFactory();
+		synchronized (submodelLock) {
+			SubmodelElementValueMapperFactory submodelElementValueFactory = new SubmodelElementValueMapperFactory();
 
-		ValueMapper<SubmodelElementValue> valueMapper = submodelElementValueFactory.create(getSubmodelElement(idShort));
+			ValueMapper<SubmodelElementValue> valueMapper = submodelElementValueFactory.create(getSubmodelElement(idShort));
 
-		valueMapper.setValue(value);
+			valueMapper.setValue(value);
+		}
 	}
 
 	@Override
 	public void createSubmodelElement(SubmodelElement submodelElement) throws CollidingIdentifierException {
-		List<SubmodelElement> smElements = submodel.getSubmodelElements();
-		synchronized (smElements) {
+		synchronized (submodelLock) {
+			List<SubmodelElement> smElements = submodel.getSubmodelElements();
 			throwIfSubmodelElementExists(submodelElement.getIdShort());
 			smElements.add(submodelElement);
-			submodel.setSubmodelElements(smElements);
 		}
 	}
 
@@ -143,45 +146,51 @@ public class InMemorySubmodelService implements SubmodelService {
 
 	@Override
 	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException, CollidingIdentifierException {
-		throwIfSubmodelElementExists(getFullIdShortPath(idShortPath, submodelElement.getIdShort()));
-
-		SubmodelElement parentSme = parser.getSubmodelElementFromIdShortPath(idShortPath);
-		if (parentSme instanceof SubmodelElementList) {
-			SubmodelElementList list = (SubmodelElementList) parentSme;
-			List<SubmodelElement> submodelElements = list.getValue();
-			list.setValue(submodelElements);
-			createSubmodelElement(submodelElement);
-			return;
-		}
-		if (parentSme instanceof SubmodelElementCollection) {
-			SubmodelElementCollection collection = (SubmodelElementCollection) parentSme;
-			List<SubmodelElement> submodelElements = collection.getValue();
-			collection.setValue(submodelElements);
-			createSubmodelElement(submodelElement);
+		synchronized (submodelLock) {
+			throwIfSubmodelElementExists(getFullIdShortPath(idShortPath, submodelElement.getIdShort()));
+			
+			SubmodelElement parentSme = parser.getSubmodelElementFromIdShortPath(idShortPath);
+			if (parentSme instanceof SubmodelElementList) {
+				SubmodelElementList list = (SubmodelElementList) parentSme;
+				List<SubmodelElement> submodelElements = list.getValue();
+				submodelElements.add(submodelElement);
+				list.setValue(submodelElements);
+				return;
+			}
+			if (parentSme instanceof SubmodelElementCollection) {
+				SubmodelElementCollection collection = (SubmodelElementCollection) parentSme;
+				List<SubmodelElement> submodelElements = collection.getValue();
+				submodelElements.add(submodelElement);
+				collection.setValue(submodelElements);
+			}
 		}
 	}
 
 	@Override
 	public void updateSubmodelElement(String idShortPath, SubmodelElement submodelElement) {
-		deleteSubmodelElement(idShortPath);
+		synchronized (submodelLock) {
+			deleteSubmodelElement(idShortPath);
 
-		String idShortPathParentSME = parser.getIdShortPathOfParentElement(idShortPath);
-		if (idShortPath.equals(idShortPathParentSME)) {
-			createSubmodelElement(submodelElement);
-			return;
+			String idShortPathParentSME = parser.getIdShortPathOfParentElement(idShortPath);
+			if (idShortPath.equals(idShortPathParentSME)) {
+				createSubmodelElement(submodelElement);
+				return;
+			}
+			createSubmodelElement(idShortPathParentSME, submodelElement);
 		}
-		createSubmodelElement(idShortPathParentSME, submodelElement);
 	}
 
 	@Override
 	public void deleteSubmodelElement(String idShortPath) throws ElementDoesNotExistException {
-		deleteAssociatedFileIfAny(idShortPath);
+		synchronized (submodelLock) {
+			deleteAssociatedFileIfAny(idShortPath);
 
-		if (!helper.isNestedIdShortPath(idShortPath)) {
-			deleteFlatSubmodelElement(idShortPath);
-			return;
+			if (!helper.isNestedIdShortPath(idShortPath)) {
+				deleteFlatSubmodelElement(idShortPath);
+				return;
+			}
+			deleteNestedSubmodelElement(idShortPath);
 		}
-		deleteNestedSubmodelElement(idShortPath);
 	}
 
 	private void deleteNestedSubmodelElement(String idShortPath) {
@@ -259,44 +268,48 @@ public class InMemorySubmodelService implements SubmodelService {
 
 	@Override
 	public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		SubmodelElement submodelElement = getSubmodelElement(idShortPath);
+		synchronized (submodelLock) {
+			SubmodelElement submodelElement = getSubmodelElement(idShortPath);
 
-		throwIfSmElementIsNotAFile(submodelElement);
+			throwIfSmElementIsNotAFile(submodelElement);
 
-		File fileSmElement = (File) submodelElement;
+			File fileSmElement = (File) submodelElement;
 
-		if (fileRepository.exists(fileSmElement.getValue()))
-			fileRepository.delete(fileSmElement.getValue());
+			if (fileRepository.exists(fileSmElement.getValue()))
+				fileRepository.delete(fileSmElement.getValue());
 
-		String uniqueFileName = createUniqueFileName(idShortPath, fileName);
+			String uniqueFileName = createUniqueFileName(idShortPath, fileName);
 
-		FileMetadata fileMetadata = new FileMetadata(uniqueFileName, fileSmElement.getContentType(), inputStream);
-		
-		if(fileRepository.exists(fileMetadata.getFileName()))
-			fileRepository.delete(fileMetadata.getFileName());
+			FileMetadata fileMetadata = new FileMetadata(uniqueFileName, fileSmElement.getContentType(), inputStream);
 
-		String filePath = fileRepository.save(fileMetadata);
+			if (fileRepository.exists(fileMetadata.getFileName()))
+				fileRepository.delete(fileMetadata.getFileName());
 
-		FileBlobValue fileValue = new FileBlobValue(fileSmElement.getContentType(), filePath);
+			String filePath = fileRepository.save(fileMetadata);
 
-		setSubmodelElementValue(idShortPath, fileValue);
+			FileBlobValue fileValue = new FileBlobValue(fileSmElement.getContentType(), filePath);
+
+			setSubmodelElementValue(idShortPath, fileValue);
+		}
 
 	}
 
 	@Override
 	public void deleteFileValue(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
-		SubmodelElement submodelElement = getSubmodelElement(idShortPath);
+		synchronized (submodelLock) {
+			SubmodelElement submodelElement = getSubmodelElement(idShortPath);
 
-		throwIfSmElementIsNotAFile(submodelElement);
+			throwIfSmElementIsNotAFile(submodelElement);
 
-		File fileSubmodelElement = (File) submodelElement;
-		String filePath = fileSubmodelElement.getValue();
+			File fileSubmodelElement = (File) submodelElement;
+			String filePath = fileSubmodelElement.getValue();
 
-		fileRepository.delete(filePath);
+			fileRepository.delete(filePath);
 
-		FileBlobValue fileValue = new FileBlobValue(" ", " ");
+			FileBlobValue fileValue = new FileBlobValue(" ", " ");
 
-		setSubmodelElementValue(idShortPath, fileValue);
+			setSubmodelElementValue(idShortPath, fileValue);
+		}
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelService.java
@@ -124,11 +124,12 @@ public class InMemorySubmodelService implements SubmodelService {
 
 	@Override
 	public void createSubmodelElement(SubmodelElement submodelElement) throws CollidingIdentifierException {
-		throwIfSubmodelElementExists(submodelElement.getIdShort());
-
 		List<SubmodelElement> smElements = submodel.getSubmodelElements();
-		smElements.add(submodelElement);
-		submodel.setSubmodelElements(smElements);
+		synchronized (smElements) {
+			throwIfSubmodelElementExists(submodelElement.getIdShort());
+			smElements.add(submodelElement);
+			submodel.setSubmodelElements(smElements);
+		}
 	}
 
 	private void throwIfSubmodelElementExists(String submodelElementId) {
@@ -148,16 +149,15 @@ public class InMemorySubmodelService implements SubmodelService {
 		if (parentSme instanceof SubmodelElementList) {
 			SubmodelElementList list = (SubmodelElementList) parentSme;
 			List<SubmodelElement> submodelElements = list.getValue();
-			submodelElements.add(submodelElement);
 			list.setValue(submodelElements);
+			createSubmodelElement(submodelElement);
 			return;
 		}
 		if (parentSme instanceof SubmodelElementCollection) {
 			SubmodelElementCollection collection = (SubmodelElementCollection) parentSme;
 			List<SubmodelElement> submodelElements = collection.getValue();
-			submodelElements.add(submodelElement);
 			collection.setValue(submodelElements);
-			return;
+			createSubmodelElement(submodelElement);
 		}
 	}
 


### PR DESCRIPTION
This PR addresses:

- an issue where a 409 error code occurs when executing the ConnectedAasManager::createSubmodelInAas function in parallel.
- an issue where a 500 error code when executing the same method but while adding smRefs to AASs