### PR TITLE
Refine Post Response Handling for Submodel Repository and Service

### DIFF
--- a/basyx.submodelrepository/basyx.submodelrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/backend/CrudSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/backend/CrudSubmodelRepository.java
@@ -197,23 +197,21 @@ public class CrudSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement smElement) {
+	public void createSubmodelElement(String submodelId, SubmodelElement smElement) {
 		SubmodelService submodelService = getSubmodelServiceOrThrow(submodelId);
 
-		SubmodelElement createdSME = submodelService.createSubmodelElement(smElement);
+		submodelService.createSubmodelElement(smElement);
 
 		updateSubmodel(submodelId, submodelService.getSubmodel());
-		return createdSME;
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
 		SubmodelService submodelService = getSubmodelServiceOrThrow(submodelId);
 
-		SubmodelElement createdSME = submodelService.createSubmodelElement(idShortPath, smElement);
+		submodelService.createSubmodelElement(idShortPath, smElement);
 
 		updateSubmodel(submodelId, submodelService.getSubmodel());
-		return createdSME;
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/ConnectedSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/ConnectedSubmodelRepository.java
@@ -196,13 +196,13 @@ public class ConnectedSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement smElement) {
-		return getConnectedSubmodelService(submodelId).createSubmodelElement(smElement);
+	public void createSubmodelElement(String submodelId, SubmodelElement smElement) {
+		getConnectedSubmodelService(submodelId).createSubmodelElement(smElement);
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
-		return getConnectedSubmodelService(submodelId).createSubmodelElement(idShortPath, smElement);
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
+		getConnectedSubmodelService(submodelId).createSubmodelElement(idShortPath, smElement);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/SubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/SubmodelRepository.java
@@ -164,7 +164,7 @@ public interface SubmodelRepository {
 	 * @param smElement
 	 *            the SubmodelElement
 	 */
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement smElement);
+	public void createSubmodelElement(String submodelId, SubmodelElement smElement);
 
 	/**
 	 * Creates a nested SubmodelElement
@@ -176,7 +176,7 @@ public interface SubmodelRepository {
 	 * @param smElement
 	 *            the SubmodelElement
 	 */
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException;
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException;
 
 	/**
 	 * Deletes a SubmodelElement

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositorySubmodelServiceWrapper.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositorySubmodelServiceWrapper.java
@@ -86,14 +86,14 @@ public class SubmodelRepositorySubmodelServiceWrapper implements SubmodelService
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(SubmodelElement submodelElement) {
-		return repoApi.createSubmodelElement(submodelId, submodelElement);
+	public void createSubmodelElement(SubmodelElement submodelElement) {
+		repoApi.createSubmodelElement(submodelId, submodelElement);
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String idShortPath, SubmodelElement submodelElement)
+	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement)
 			throws ElementDoesNotExistException {
-		return repoApi.createSubmodelElement(submodelId, idShortPath, submodelElement);
+		repoApi.createSubmodelElement(submodelId, idShortPath, submodelElement);
 		
 	}
 

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/authorization/AuthorizedSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/authorization/AuthorizedSubmodelRepository.java
@@ -205,21 +205,21 @@ public class AuthorizedSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement smElement) {
+	public void createSubmodelElement(String submodelId, SubmodelElement smElement) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new SubmodelTargetInformation(getIdAsList(submodelId), getIdAsList(ALL_ALLOWED_WILDCARD)));
 
 		throwExceptionIfInsufficientPermission(isAuthorized);
 
-		return decorated.createSubmodelElement(submodelId, smElement);
+		decorated.createSubmodelElement(submodelId, smElement);
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new SubmodelTargetInformation(getIdAsList(submodelId), getIdAsList(idShortPath)));
 
 		throwExceptionIfInsufficientPermission(isAuthorized);
 
-		return decorated.createSubmodelElement(submodelId, idShortPath, smElement);
+		decorated.createSubmodelElement(submodelId, idShortPath, smElement);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/MqttSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/MqttSubmodelRepository.java
@@ -125,17 +125,17 @@ public class MqttSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement smElement) {
-		SubmodelElement submodelElement = decorated.createSubmodelElement(submodelId, smElement);
+	public void createSubmodelElement(String submodelId, SubmodelElement smElement) {
+		decorated.createSubmodelElement(submodelId, smElement);
+		SubmodelElement submodelElement = decorated.getSubmodelElement(submodelId, smElement.getIdShort());
 		submodelElementCreated(submodelElement, getName(), submodelId, smElement.getIdShort());
-		return submodelElement;
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
-		SubmodelElement submodelElement = decorated.createSubmodelElement(submodelId, smElement);
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
+		decorated.createSubmodelElement(submodelId, idShortPath, smElement);
+		SubmodelElement submodelElement = decorated.getSubmodelElement(submodelId, idShortPath);
 		submodelElementCreated(submodelElement, getName(), submodelId, idShortPath);
-		return submodelElement;
 	}
 	
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/TestMqttSubmodelObserver.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/TestMqttSubmodelObserver.java
@@ -10,10 +10,10 @@ package org.eclipse.digitaltwin.basyx.submodelrepository.feature.mqtt;
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -86,13 +86,13 @@ public class TestMqttSubmodelObserver {
 	private static MqttSubmodelRepositoryTopicFactory topicFactory = new MqttSubmodelRepositoryTopicFactory(new Base64URLEncoder());
 
 	private static SubmodelRepository submodelRepository;
-
+	
 	private static JsonDeserializer deserializer = new JsonDeserializer();
 
 	private static final String FILE_SUBMODEL_ELEMENT_NAME = "testFile.txt";
 	private static final String FILE_SUBMODEL_ELEMENT_CONTENT = "This is a text file.";
 	private static String SAVED_FILE_PATH = "";
-
+	
 	@BeforeClass
 	public static void setUpClass() throws MqttException, IOException {
 		mqttBroker = startBroker();
@@ -145,9 +145,8 @@ public class TestMqttSubmodelObserver {
 		Submodel submodel = createSubmodelDummy("createSubmodelForElementEventId");
 		submodelRepository.createSubmodel(submodel);
 		SubmodelElement submodelElement = createSubmodelElementDummy("createSubmodelElementEventId");
-		SubmodelElement responseSubmodelElement = submodelRepository.createSubmodelElement(submodel.getId(), submodelElement);
+		submodelRepository.createSubmodelElement(submodel.getId(), submodelElement);
 
-		assertEquals(submodelElement, responseSubmodelElement);
 		assertEquals(topicFactory.createCreateSubmodelElementTopic(submodelRepository.getName(), submodel.getId(), submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
 	}
@@ -156,9 +155,8 @@ public class TestMqttSubmodelObserver {
 	public void updateSubmodelElementEvent() throws DeserializationException {
 		Submodel submodel = createSubmodelDummyWithSubmodelElement("updateSubmodelForElementEventId", "updateSubmodelElementEventId");
 		submodelRepository.createSubmodel(submodel);
-
 		SubmodelElement submodelElement = submodel.getSubmodelElements().get(0);
-
+		
 		SubmodelElementValue value = new PropertyValue("updatedValue");
 		submodelRepository.setSubmodelElementValue(submodel.getId(), submodelElement.getIdShort(), value);
 
@@ -170,9 +168,9 @@ public class TestMqttSubmodelObserver {
 	public void deleteSubmodelElementEvent() throws DeserializationException {
 		Submodel submodel = createSubmodelDummyWithSubmodelElement("deleteSubmodelForElementEventId", "deleteSubmodelElementEventId");
 		submodelRepository.createSubmodel(submodel);
-
+		
 		SubmodelElement submodelElement = submodel.getSubmodelElements().get(0);
-
+		
 		submodelRepository.deleteSubmodelElement(submodel.getId(), submodelElement.getIdShort());
 
 		assertEquals(topicFactory.createDeleteSubmodelElementTopic(submodelRepository.getName(), submodel.getId(), submodelElement.getIdShort()), listener.lastTopic);
@@ -186,9 +184,8 @@ public class TestMqttSubmodelObserver {
 		SubmodelElement submodelElement = createSubmodelElementDummy("noValueSubmodelElementEventId");
 		List<Qualifier> qualifierList = createNoValueQualifierList();
 		submodelElement.setQualifiers(qualifierList);
-		SubmodelElement responseSubmodelElement = submodelRepository.createSubmodelElement(submodel.getId(), submodelElement);
+		submodelRepository.createSubmodelElement(submodel.getId(), submodelElement);
 
-		assertEquals(submodelElement, responseSubmodelElement);
 		assertEquals(topicFactory.createCreateSubmodelElementTopic(submodelRepository.getName(), submodel.getId(), submodelElement.getIdShort()), listener.lastTopic);
 		assertNotEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
 
@@ -201,46 +198,46 @@ public class TestMqttSubmodelObserver {
 	public void patchSubmodelElementsEvent() throws DeserializationException, JsonMappingException, JsonProcessingException {
 		Submodel submodel = createSubmodelDummyWithSubmodelElements("patchSubmodelForElementEventId");
 		submodelRepository.createSubmodel(submodel);
-
+		
 		List<SubmodelElement> submodelElements = submodel.getSubmodelElements();
-
+		
 		for (int i = 0; i < submodelElements.size(); i++) {
 			SubmodelElement submodelElement = submodelElements.get(i);
 			submodelElement.setIdShort("patchedSubmodelElementId_" + i);
 		}
 
 		submodelRepository.patchSubmodelElements(submodel.getId(), submodelElements);
-
+		
 		assertEquals(topicFactory.createPatchSubmodelElementsTopic(submodelRepository.getName(), submodel.getId()), listener.lastTopic);
 		assertEquals(submodelElements, deserializeSubmodelElementsListPayload(listener.lastPayload));
 	}
-
+	
 	@Test
 	public void setFileValueEvent() throws DeserializationException, IOException {
 		Submodel submodel = createSubmodelDummyWithFileSubmodelElement("setSubmodelFileValueEventId", "setFileValueSubmodelElementEventId");
 		submodelRepository.createSubmodel(submodel);
-
-		File submodelElement = (File) submodel.getSubmodelElements().get(0);
-
+	
+		File submodelElement = (File) submodel.getSubmodelElements().get(0); 
+		
 		submodelRepository.setFileValue(submodel.getId(), submodelElement.getIdShort(), FILE_SUBMODEL_ELEMENT_NAME, getInputStreamOfDummyFile(FILE_SUBMODEL_ELEMENT_CONTENT));
-
+		
 		assertEquals(topicFactory.createUpdateFileValueTopic(submodelRepository.getName(), submodel.getId(), submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
 	}
-
+	
 	@Test
 	public void deleteFileValueEvent() throws DeserializationException, IOException {
 		Submodel submodel = createSubmodelDummyWithFileSubmodelElement("deleteSubmodelFileValueEventId", "deleteFileValueSubmodelElementEventId");
 		submodelRepository.createSubmodel(submodel);
-
+	
 		File submodelElement = (File) submodel.getSubmodelElements().get(0);
-
+		
 		submodelRepository.deleteFileValue(submodel.getId(), submodelElement.getIdShort());
 
 		assertEquals(topicFactory.createDeleteFileValueTopic(submodelRepository.getName(), submodel.getId(), submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
 	}
-
+	
 	private List<Qualifier> createNoValueQualifierList() {
 		Qualifier emptyValueQualifier = new DefaultQualifier.Builder().type(SubmodelElementSerializer.EMPTYVALUEUPDATE_TYPE).value("true").build();
 		return Arrays.asList(emptyValueQualifier);
@@ -253,66 +250,66 @@ public class TestMqttSubmodelObserver {
 	private SubmodelElement deserializeSubmodelElementPayload(String payload) throws DeserializationException {
 		return new JsonDeserializer().read(payload, SubmodelElement.class);
 	}
-
-	private List<SubmodelElement> deserializeSubmodelElementsListPayload(String payload) throws DeserializationException, JsonMappingException, JsonProcessingException {
+	 
+	private List<SubmodelElement> deserializeSubmodelElementsListPayload(String payload) throws DeserializationException, JsonMappingException, JsonProcessingException {			
 		return deserializer.readList(payload, SubmodelElement.class);
 	}
 
 	private Submodel createSubmodelDummy(String submodelId) {
 		return new DefaultSubmodel.Builder().id(submodelId).build();
 	}
-
+	
 	private Submodel createSubmodelDummyWithSubmodelElement(String submodelId, String submodelElementId) {
 		List<SubmodelElement> submodelElements = new ArrayList<>();
-
+		
 		submodelElements.add(createSubmodelElementDummy(submodelElementId));
-
+		
 		return new DefaultSubmodel.Builder().id(submodelId).submodelElements(submodelElements).build();
 	}
-
+	
 	private Submodel createSubmodelDummyWithFileSubmodelElement(String submodelId, String submodelElementId) {
 		List<SubmodelElement> submodelElements = new ArrayList<>();
-
+		
 		submodelElements.add(createFileSubmodelElement(submodelElementId));
-
+		
 		return new DefaultSubmodel.Builder().id(submodelId).submodelElements(submodelElements).build();
 	}
-
+	
 	private Submodel createSubmodelDummyWithSubmodelElements(String submodelId) {
 		List<SubmodelElement> submodelElements = createSubmodelElementsListDummy(2);
-
+		
 		return new DefaultSubmodel.Builder().id(submodelId).submodelElements(submodelElements).build();
 	}
 
 	private SubmodelElement createSubmodelElementDummy(String submodelElementId) {
 		Property defaultProp = new DefaultProperty.Builder().idShort(submodelElementId).value("defaultValue").build();
-
+		
 		return new DefaultProperty.Builder().idShort(submodelElementId).value("defaultValue").build();
 	}
-
+	
 	public File createFileSubmodelElement(String submodelElementId) {
 		return new DefaultFile.Builder().idShort(submodelElementId).value(SAVED_FILE_PATH).contentType("text/plain").build();
 	}
-
+	
 	private static InputStream getInputStreamOfDummyFile(String fileContent) throws FileNotFoundException, IOException {
 		return new ByteArrayInputStream(fileContent.getBytes());
 	}
-
+	
 	private List<SubmodelElement> createSubmodelElementsListDummy(int count) {
 		List<SubmodelElement> submodelElements = new ArrayList<SubmodelElement>();
-
+		
 		for (int i = 0; i < count; i++) {
 			submodelElements.add(createSubmodelElementDummy("submodelElementId_" + i));
 		}
-
+		
 		return submodelElements;
 	}
 
 	private static SubmodelRepository createMqttSubmodelRepository(MqttClient client) throws FileHandlingException, FileNotFoundException, IOException {
 		FileRepository fileRepository = new InMemoryFileRepository();
-
+		
 		SAVED_FILE_PATH = fileRepository.save(new FileMetadata(FILE_SUBMODEL_ELEMENT_NAME, "", getInputStreamOfDummyFile(FILE_SUBMODEL_ELEMENT_CONTENT)));
-
+		
 		SubmodelRepositoryFactory repoFactory = new SimpleSubmodelRepositoryFactory(new SubmodelInMemoryBackendProvider(), new InMemorySubmodelServiceFactory(fileRepository));
 
 		return new MqttSubmodelRepositoryFactory(repoFactory, client, new MqttSubmodelRepositoryTopicFactory(new Base64URLEncoder())).create();

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-operation-delegation/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/operation/delegation/OperationDelegationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-operation-delegation/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/operation/delegation/OperationDelegationSubmodelRepository.java
@@ -117,13 +117,13 @@ public class OperationDelegationSubmodelRepository implements SubmodelRepository
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement smElement) {
-		return decorated.createSubmodelElement(submodelId, smElement);
+	public void createSubmodelElement(String submodelId, SubmodelElement smElement) {
+		decorated.createSubmodelElement(submodelId, smElement);
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
-		return decorated.createSubmodelElement(submodelId, idShortPath, smElement);
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement smElement) throws ElementDoesNotExistException {
+		decorated.createSubmodelElement(submodelId, idShortPath, smElement);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
@@ -134,13 +134,13 @@ public class RegistryIntegrationSubmodelRepository implements SubmodelRepository
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, SubmodelElement submodelElement) {
-		return decorated.createSubmodelElement(submodelId, submodelElement);
+	public void createSubmodelElement(String submodelId, SubmodelElement submodelElement) {
+		decorated.createSubmodelElement(submodelId, submodelElement);
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String submodelId, String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
-		return decorated.createSubmodelElement(submodelId, idShortPath, submodelElement);
+	public void createSubmodelElement(String submodelId, String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
+		decorated.createSubmodelElement(submodelId, idShortPath, submodelElement);
 	}
 	
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
@@ -177,14 +177,14 @@ public class SubmodelRepositoryApiHTTPController implements SubmodelRepositoryHT
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementByPathSubmodelRepo(Base64UrlEncodedIdentifier submodelIdentifier, String idShortPath, @Valid SubmodelElement body, @Valid String level, @Valid String extent) {
-		SubmodelElement createdSME = repository.createSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath, body);
-		return new ResponseEntity<SubmodelElement>(createdSME, HttpStatus.CREATED);
+		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath, body);
+		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
 	}
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementSubmodelRepo(Base64UrlEncodedIdentifier submodelIdentifier, @Valid SubmodelElement body) {
-	    SubmodelElement createdSME = repository.createSubmodelElement(submodelIdentifier.getIdentifier(), body);
-	    return new ResponseEntity<SubmodelElement>(createdSME, HttpStatus.CREATED);
+		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), body);
+		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationRequest;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationResult;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
@@ -45,6 +46,7 @@ import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifier;
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifierSize;
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncoder;
+import org.eclipse.digitaltwin.basyx.http.CustomTypeCloneFactory;
 import org.eclipse.digitaltwin.basyx.http.pagination.Base64UrlEncodedCursor;
 import org.eclipse.digitaltwin.basyx.http.pagination.PagedResult;
 import org.eclipse.digitaltwin.basyx.http.pagination.PagedResultPagingMetadata;
@@ -77,12 +79,14 @@ import jakarta.validation.constraints.Min;
 @RestController
 public class SubmodelRepositoryApiHTTPController implements SubmodelRepositoryHTTPApi {
 
-	private SubmodelRepository repository;
+	private final SubmodelRepository repository;
+	private final ObjectMapper objectMapper;
 
 	@Autowired
-	public SubmodelRepositoryApiHTTPController(SubmodelRepository repository) {
+	public SubmodelRepositoryApiHTTPController(SubmodelRepository repository, ObjectMapper objectMapper) {
 		this.repository = repository;
-	}
+        this.objectMapper = objectMapper;
+    }
 
 	@Override
 	public ResponseEntity<Submodel> postSubmodel(@Parameter(in = ParameterIn.DEFAULT, description = "Submodel object", required = true, schema = @Schema()) @Valid @RequestBody Submodel body) {
@@ -177,14 +181,18 @@ public class SubmodelRepositoryApiHTTPController implements SubmodelRepositoryHT
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementByPathSubmodelRepo(Base64UrlEncodedIdentifier submodelIdentifier, String idShortPath, @Valid SubmodelElement body, @Valid String level, @Valid String extent) {
-		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath, body);
-		return new ResponseEntity<>(repository.getSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath), HttpStatus.CREATED);
+		SubmodelElement validatedBody = new CustomTypeCloneFactory<>(SubmodelElement.class, objectMapper).create(body);
+
+		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath, validatedBody);
+		return new ResponseEntity<>(validatedBody, HttpStatus.CREATED);
 	}
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementSubmodelRepo(Base64UrlEncodedIdentifier submodelIdentifier, @Valid SubmodelElement body) {
-		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), body);
-		return new ResponseEntity<>(repository.getSubmodelElement(submodelIdentifier.getIdentifier(), body.getIdShort()), HttpStatus.CREATED);
+		SubmodelElement validatedBody = new CustomTypeCloneFactory<>(SubmodelElement.class, objectMapper).create(body);
+
+		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), validatedBody);
+		return new ResponseEntity<>(validatedBody, HttpStatus.CREATED);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
@@ -178,13 +178,13 @@ public class SubmodelRepositoryApiHTTPController implements SubmodelRepositoryHT
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementByPathSubmodelRepo(Base64UrlEncodedIdentifier submodelIdentifier, String idShortPath, @Valid SubmodelElement body, @Valid String level, @Valid String extent) {
 		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath, body);
-		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
+		return new ResponseEntity<>(repository.getSubmodelElement(submodelIdentifier.getIdentifier(), idShortPath), HttpStatus.CREATED);
 	}
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementSubmodelRepo(Base64UrlEncodedIdentifier submodelIdentifier, @Valid SubmodelElement body) {
 		repository.createSubmodelElement(submodelIdentifier.getIdentifier(), body);
-		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
+		return new ResponseEntity<>(repository.getSubmodelElement(submodelIdentifier.getIdentifier(), body.getIdShort()), HttpStatus.CREATED);
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/InMemorySubmodelService.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (C) 2023 the Eclipse BaSyx Authors
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -19,7 +19,7 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+ * 
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
@@ -62,9 +62,9 @@ import org.eclipse.digitaltwin.basyx.submodelservice.value.mapper.ValueMapper;
 
 /**
  * Implements the SubmodelService as in-memory variant
- *
+ * 
  * @author schnicke, danish, mateusmolina
- *
+ * 
  */
 public class InMemorySubmodelService implements SubmodelService {
 
@@ -78,7 +78,7 @@ public class InMemorySubmodelService implements SubmodelService {
 
 	/**
 	 * Creates the InMemory SubmodelService containing the passed Submodel
-	 *
+	 * 
 	 * @param submodel
 	 */
 	public InMemorySubmodelService(Submodel submodel, FileRepository fileRepository) {
@@ -128,14 +128,12 @@ public class InMemorySubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(SubmodelElement submodelElement) throws CollidingIdentifierException {
+	public void createSubmodelElement(SubmodelElement submodelElement) throws CollidingIdentifierException {
 		synchronized (submodelLock) {
 			List<SubmodelElement> smElements = submodel.getSubmodelElements();
 			throwIfSubmodelElementExists(submodelElement.getIdShort());
 			smElements.add(submodelElement);
 		}
-
-		return submodelElement;
 	}
 
 	private void throwIfSubmodelElementExists(String submodelElementId) {
@@ -148,10 +146,10 @@ public class InMemorySubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException, CollidingIdentifierException {
+	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException, CollidingIdentifierException {
 		synchronized (submodelLock) {
 			throwIfSubmodelElementExists(getFullIdShortPath(idShortPath, submodelElement.getIdShort()));
-
+			
 			SubmodelElement parentSme = parser.getSubmodelElementFromIdShortPath(idShortPath);
 			if (parentSme instanceof SubmodelElementList) {
 				SubmodelElementList list = (SubmodelElementList) parentSme;
@@ -167,8 +165,6 @@ public class InMemorySubmodelService implements SubmodelService {
 				submodelElements.add(submodelElement);
 			}
 		}
-
-		return submodelElement;
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/MongoDBSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/MongoDBSubmodelService.java
@@ -103,21 +103,19 @@ public class MongoDBSubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(SubmodelElement submodelElement) {
+	public void createSubmodelElement(SubmodelElement submodelElement) {
 		InMemorySubmodelService inMemorySubmodelService = getInMemorySubmodelService();
-		SubmodelElement createdSME = inMemorySubmodelService.createSubmodelElement(submodelElement);
+		inMemorySubmodelService.createSubmodelElement(submodelElement);
 		Submodel submodel = inMemorySubmodelService.getSubmodel();
 		crudRepository.save(submodel);
-		return createdSME;
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
+	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
 		InMemorySubmodelService inMemorySubmodelService = getInMemorySubmodelService();
-		SubmodelElement createdSME = inMemorySubmodelService.createSubmodelElement(idShortPath, submodelElement);
+		inMemorySubmodelService.createSubmodelElement(idShortPath, submodelElement);
 		Submodel submodel = inMemorySubmodelService.getSubmodel();
 		crudRepository.save(submodel);
-		return createdSME;
 
 	}
 

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/ConnectedSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/ConnectedSubmodelService.java
@@ -113,14 +113,14 @@ public class ConnectedSubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(SubmodelElement submodelElement) {
-		return serviceApi.postSubmodelElement(submodelElement);
+	public void createSubmodelElement(SubmodelElement submodelElement) {
+		serviceApi.postSubmodelElement(submodelElement);
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
+	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
 		try {
-			return serviceApi.postSubmodelElementByPath(idShortPath, submodelElement);
+			serviceApi.postSubmodelElementByPath(idShortPath, submodelElement);
 		} catch (ApiException e) {
 			throw mapExceptionSubmodelElementAccess(idShortPath, e);
 		}

--- a/basyx.submodelservice/basyx.submodelservice-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelService.java
@@ -92,7 +92,7 @@ public interface SubmodelService {
 	 * Creates a Submodel Element
 	 * 
 	 */
-	public SubmodelElement createSubmodelElement(SubmodelElement submodelElement);
+	public void createSubmodelElement(SubmodelElement submodelElement);
 
 	/**
 	 * Create a nested submodel element
@@ -101,18 +101,16 @@ public interface SubmodelService {
 	 *            the SubmodelElement IdShortPath
 	 * @param submodelElement
 	 *            the submodel element to be created
-	 * @return the SubmodelElement
 	 * @throws ElementDoesNotExistException
 	 *             If the submodel element defined in the path does not exist
 	 */
-	public SubmodelElement createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException;
+	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException;
 	
 	/**
 	 * Updates a submodel element
 	 * 
 	 * @param idShortPath
 	 * @param submodelElement
-	 * @return the SubmodelElement
 	 * @throws ElementDoesNotExistException
 	 *             If the submodel element defined in the path does not exist
 	 */

--- a/basyx.submodelservice/basyx.submodelservice-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelServiceHelper.java
+++ b/basyx.submodelservice/basyx.submodelservice-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelServiceHelper.java
@@ -358,14 +358,6 @@ public class SubmodelServiceHelper {
 				.build();
 	}
 	
-	public static SubmodelElement createDummySME(String idShort, String value, DataTypeDefXsd dataType) {
-		return new DefaultProperty.Builder().idShort(idShort)
-				.category("cat1")
-				.value(value)
-				.valueType(dataType)
-				.build();
-	}
-	
 	public static File createDummyFile(String idShort, String contentType, String value) {
 		return new DefaultFile.Builder().idShort(idShort)
 				.category("file")

--- a/basyx.submodelservice/basyx.submodelservice-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelServiceSuite.java
+++ b/basyx.submodelservice/basyx.submodelservice-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelServiceSuite.java
@@ -718,10 +718,6 @@ public abstract class SubmodelServiceSuite {
 	private DefaultProperty createDummyProperty(String idShort) {
 		return new DefaultProperty.Builder().idShort(idShort).category("cat1").value("123").valueType(DataTypeDefXsd.INTEGER).build();
 	}
-	
-	private SubmodelElement createDummySME(String idShort) {
-		return new DefaultProperty.Builder().idShort(idShort).value("123").build();
-	}
 
 	private InputStream getInputStreamOfDummyFile(String fileContent) throws FileNotFoundException, IOException {
 		return new ByteArrayInputStream(fileContent.getBytes());

--- a/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/mqtt/MqttSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/mqtt/MqttSubmodelService.java
@@ -93,18 +93,19 @@ public class MqttSubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(SubmodelElement submodelElement) {
-		SubmodelElement createdSME = decorated.createSubmodelElement(submodelElement);
-		submodelElementCreated(submodelElement, createdSME.getIdShort());
-		return createdSME;
+	public void createSubmodelElement(SubmodelElement submodelElement) {
+		decorated.createSubmodelElement(submodelElement);
+		SubmodelElement smElement = decorated.getSubmodelElement(submodelElement.getIdShort());
+		submodelElementCreated(submodelElement, smElement.getIdShort());
 	}
 
 	@Override
-	public SubmodelElement createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
+	public void createSubmodelElement(String idShortPath, SubmodelElement submodelElement) throws ElementDoesNotExistException {
 
-		SubmodelElement createdSME = decorated.createSubmodelElement(idShortPath, submodelElement);
-		submodelElementCreated(createdSME, idShortPath);
-		return createdSME;
+		decorated.createSubmodelElement(idShortPath, submodelElement);
+
+		SubmodelElement smElement = decorated.getSubmodelElement(submodelElement.getIdShort());
+		submodelElementCreated(smElement, idShortPath);
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/TestMqttSubmodelObserver.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/TestMqttSubmodelObserver.java
@@ -97,37 +97,34 @@ public class TestMqttSubmodelObserver {
 	public void createSubmodelElementEvent() throws DeserializationException {
 
 		SubmodelElement submodelElement = createSubmodelElementDummy("createSubmodelElementEventId");
-		SubmodelElement responseSubmodelElement = submodelService.createSubmodelElement(submodelElement);
+		submodelService.createSubmodelElement(submodelElement);
 
 		assertEquals(topicFactory.createCreateSubmodelElementTopic(submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
-		assertEquals(submodelElement, responseSubmodelElement);
 	}
 
 	@Test
 	public void updateSubmodelElementEvent() throws DeserializationException {
 
 		SubmodelElement submodelElement = createSubmodelElementDummy("updateSubmodelElementEventId");
-		SubmodelElement responseSubmodelElement = submodelService.createSubmodelElement(submodelElement);
+		submodelService.createSubmodelElement(submodelElement);
 
 		SubmodelElementValue value = new PropertyValue("updatedValue");
 		submodelService.setSubmodelElementValue(submodelElement.getIdShort(), value);
 
 		assertEquals(topicFactory.createUpdateSubmodelElementTopic(submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
-		assertEquals(submodelElement, responseSubmodelElement);
 	}
 
 	@Test
 	public void deleteSubmodelElementEvent() throws DeserializationException {
 
 		SubmodelElement submodelElement = createSubmodelElementDummy("deleteSubmodelElementEventId");
-		SubmodelElement responseSubmodelElement = submodelService.createSubmodelElement(submodelElement);
+		submodelService.createSubmodelElement(submodelElement);
 		submodelService.deleteSubmodelElement(submodelElement.getIdShort());
 
 		assertEquals(topicFactory.createDeleteSubmodelElementTopic(submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
-		assertEquals(submodelElement, responseSubmodelElement);
 	}
 
 	@Test
@@ -136,14 +133,13 @@ public class TestMqttSubmodelObserver {
 		SubmodelElement submodelElement = createSubmodelElementDummy("noValueSubmodelElementEventId");
 		List<Qualifier> qualifierList = createNoValueQualifierList();
 		submodelElement.setQualifiers(qualifierList);
-		SubmodelElement responseSubmodelElement = submodelService.createSubmodelElement(submodelElement);
+		submodelService.createSubmodelElement(submodelElement);
 
 		assertEquals(topicFactory.createCreateSubmodelElementTopic(submodelElement.getIdShort()), listener.lastTopic);
 		assertNotEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
 
 		((Property) submodelElement).setValue(null);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));
-		assertEquals(submodelElement, responseSubmodelElement);
 	}
 
 	private List<Qualifier> createNoValueQualifierList() {

--- a/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
+++ b/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
@@ -196,16 +196,16 @@ public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi 
 	public ResponseEntity<SubmodelElement> postSubmodelElement(@Parameter(in = ParameterIn.DEFAULT, description = "Requested submodel element", required = true, schema = @Schema()) @Valid @RequestBody SubmodelElement body,
 			@Parameter(in = ParameterIn.QUERY, description = "Determines the structural depth of the respective resource content", schema = @Schema(allowableValues = { "deep",
 					"core" }, defaultValue = "deep")) @Valid @RequestParam(value = "level", required = false, defaultValue = "deep") String level) {
-		SubmodelElement createdSME = service.createSubmodelElement(body);
-		return new ResponseEntity<SubmodelElement>(createdSME, HttpStatus.CREATED);
+		service.createSubmodelElement(body);
+		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
 	}
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementByPath(
 			@Parameter(in = ParameterIn.PATH, description = "IdShort path to the submodel element (dot-separated)", required = true, schema = @Schema()) @PathVariable("idShortPath") String idShortPath,
 			@Parameter(in = ParameterIn.DEFAULT, description = "Requested submodel element", required = true, schema = @Schema()) @Valid @RequestBody SubmodelElement body) {
-		SubmodelElement createdSME = service.createSubmodelElement(idShortPath, body);
-		return new ResponseEntity<SubmodelElement>(createdSME, HttpStatus.CREATED);
+		service.createSubmodelElement(idShortPath, body);
+		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
 	}
 	
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
+++ b/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationRequest;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationResult;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
@@ -38,6 +39,7 @@ import org.eclipse.digitaltwin.basyx.core.exceptions.ElementNotAFileException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
+import org.eclipse.digitaltwin.basyx.http.CustomTypeCloneFactory;
 import org.eclipse.digitaltwin.basyx.http.pagination.Base64UrlEncodedCursor;
 import org.eclipse.digitaltwin.basyx.http.pagination.PagedResult;
 import org.eclipse.digitaltwin.basyx.http.pagination.PagedResultPagingMetadata;
@@ -69,12 +71,14 @@ import jakarta.validation.constraints.Min;
 @RestController
 public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi {
 
-	private SubmodelService service;
+	private final SubmodelService service;
+	private final ObjectMapper objectMapper;
 
 	@Autowired
-	public SubmodelServiceHTTPApiController(SubmodelService service) {
+	public SubmodelServiceHTTPApiController(SubmodelService service, ObjectMapper objectMapper) {
 		this.service = service;
-	}
+        this.objectMapper = objectMapper;
+    }
 
 	@Override
 	public ResponseEntity<Void> deleteSubmodelElementByPath(
@@ -196,16 +200,21 @@ public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi 
 	public ResponseEntity<SubmodelElement> postSubmodelElement(@Parameter(in = ParameterIn.DEFAULT, description = "Requested submodel element", required = true, schema = @Schema()) @Valid @RequestBody SubmodelElement body,
 			@Parameter(in = ParameterIn.QUERY, description = "Determines the structural depth of the respective resource content", schema = @Schema(allowableValues = { "deep",
 					"core" }, defaultValue = "deep")) @Valid @RequestParam(value = "level", required = false, defaultValue = "deep") String level) {
-		service.createSubmodelElement(body);
-		return new ResponseEntity<>(service.getSubmodelElement(body.getIdShort()), HttpStatus.CREATED);
+
+		SubmodelElement validatedBody = new CustomTypeCloneFactory<>(SubmodelElement.class, objectMapper).create(body);
+		service.createSubmodelElement(validatedBody);
+
+		return new ResponseEntity<>(validatedBody, HttpStatus.CREATED);
 	}
 
 	@Override
 	public ResponseEntity<SubmodelElement> postSubmodelElementByPath(
 			@Parameter(in = ParameterIn.PATH, description = "IdShort path to the submodel element (dot-separated)", required = true, schema = @Schema()) @PathVariable("idShortPath") String idShortPath,
 			@Parameter(in = ParameterIn.DEFAULT, description = "Requested submodel element", required = true, schema = @Schema()) @Valid @RequestBody SubmodelElement body) {
-		service.createSubmodelElement(idShortPath, body);
-		return new ResponseEntity<>(service.getSubmodelElement(idShortPath), HttpStatus.CREATED);
+		SubmodelElement validatedBody = new CustomTypeCloneFactory<>(SubmodelElement.class, objectMapper).create(body);
+		service.createSubmodelElement(idShortPath, validatedBody);
+
+		return new ResponseEntity<>(validatedBody, HttpStatus.CREATED);
 	}
 	
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
+++ b/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
@@ -197,7 +197,7 @@ public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi 
 			@Parameter(in = ParameterIn.QUERY, description = "Determines the structural depth of the respective resource content", schema = @Schema(allowableValues = { "deep",
 					"core" }, defaultValue = "deep")) @Valid @RequestParam(value = "level", required = false, defaultValue = "deep") String level) {
 		service.createSubmodelElement(body);
-		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
+		return new ResponseEntity<>(service.getSubmodelElement(body.getIdShort()), HttpStatus.CREATED);
 	}
 
 	@Override
@@ -205,7 +205,7 @@ public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi 
 			@Parameter(in = ParameterIn.PATH, description = "IdShort path to the submodel element (dot-separated)", required = true, schema = @Schema()) @PathVariable("idShortPath") String idShortPath,
 			@Parameter(in = ParameterIn.DEFAULT, description = "Requested submodel element", required = true, schema = @Schema()) @Valid @RequestBody SubmodelElement body) {
 		service.createSubmodelElement(idShortPath, body);
-		return new ResponseEntity<SubmodelElement>(HttpStatus.CREATED);
+		return new ResponseEntity<>(service.getSubmodelElement(idShortPath), HttpStatus.CREATED);
 	}
 	
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-http/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceSubmodelElementsTestSuiteHTTP.java
+++ b/basyx.submodelservice/basyx.submodelservice-http/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceSubmodelElementsTestSuiteHTTP.java
@@ -385,9 +385,8 @@ public abstract class SubmodelServiceSubmodelElementsTestSuiteHTTP {
 		String element = getJSONValueAsString("SubmodelElementNew.json");
 		CloseableHttpResponse createdResponse = BaSyxHttpTestUtils.executePostOnURL(createSubmodelElementsURL(), element);
 
-		CloseableHttpResponse fetchedResponse = requestSubmodelElement("MaxRotationSpeedNew");
 		assertEquals(HttpStatus.CREATED.value(), createdResponse.getCode());
-		BaSyxHttpTestUtils.assertSameJSONContent(element, BaSyxHttpTestUtils.getResponseAsString(fetchedResponse));
+		BaSyxHttpTestUtils.assertSameJSONContent(element, BaSyxHttpTestUtils.getResponseAsString(createdResponse));
 	}
 	
 	@Test


### PR DESCRIPTION
This PR revises the previous fix #484 for the response body when posting in the submodel repository and submodel service. The initial implementation included unnecessary internal API modifications. This update simplifies the approach while ensuring the correct response behavior.