### PR TITLE
Adds second unique tag to snapshot image in the CI

### DIFF
--- a/.github/workflows/docker-snapshot-release.yml
+++ b/.github/workflows/docker-snapshot-release.yml
@@ -125,6 +125,9 @@ jobs:
         if: "!contains(matrix.name, 'registry')"
         run: echo "FINAL_ARGS=" >> $GITHUB_ENV
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
@@ -134,8 +137,9 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/${{ matrix.name }}:2.0.0-SNAPSHOT
+            ${{ env.DOCKER_NAMESPACE }}/${{ matrix.name }}:2.0.0-SNAPSHOT-${{ env.SHORT_SHA }}
           build-args: ${{ env.FINAL_ARGS }}
 
       - name: Verify Docker Image
         run: |
-          docker pull ${{ env.DOCKER_NAMESPACE }}/${{ matrix.name }}:2.0.0-SNAPSHOT
+          docker pull ${{ env.DOCKER_NAMESPACE }}/${{ matrix.name }}:2.0.0-SNAPSHOT-${{ env.SHORT_SHA }}


### PR DESCRIPTION
## Description of Changes

This will improve the handling of SNAPSHOT images. Currently, there is no recent fallback image when a snapshot introduces a new bug. With this new addition there will always be a specific fallback to an older snapshot. Each merged PR will create two image tags:

- 2.0.0-SNAPSHOT (always has the latest changes and get's overwritten with each merged PR)
- 2.0.0-SNAPSHOT-<{short-comit-sha}> (specific tag for the commit created by merging a PR)