### PR TITLE
Fix for Filtering in In-Memory AASRegistry

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/AasRegistryStorageTest.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/AasRegistryStorageTest.java
@@ -32,6 +32,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonSerializer;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.basyx.aasregistry.model.AssetAdministrationShellDescriptor;
 import org.eclipse.digitaltwin.basyx.aasregistry.model.AssetKind;
 import org.eclipse.digitaltwin.basyx.aasregistry.model.LangStringTextType;
@@ -160,6 +163,40 @@ public abstract class AasRegistryStorageTest extends ExtensionsTest {
 	@Test
 	public void whenGetAllAssetAdministrationShellDescriptorsFilteredByInstance_thenOnlyInstance() throws IOException {
 		Collection<AssetAdministrationShellDescriptor> found = getAllAasDescriptorsFiltered(AssetKind.INSTANCE, null);
+		List<AssetAdministrationShellDescriptor> expected = testResourcesLoader.loadList(AssetAdministrationShellDescriptor.class);
+		assertThat(found).containsExactlyInAnyOrderElementsOf(expected);
+		verifyNoEventSent();
+	}
+	
+	@Test
+	public void whenGetAllAssetAdministrationShellDescriptorsFilteredByInstanceAndType_thenOnlyMatching() throws IOException {
+		Collection<AssetAdministrationShellDescriptor> found = getAllAasDescriptorsFiltered(AssetKind.INSTANCE, "A");
+		List<AssetAdministrationShellDescriptor> expected = testResourcesLoader.loadList(AssetAdministrationShellDescriptor.class);
+		assertThat(found).containsExactlyInAnyOrderElementsOf(expected);
+		verifyNoEventSent();
+	}
+	
+	@Test
+	public void whenGetAllAssetAdministrationShellDescriptorsFilteredByTypeAndType_thenOnlyMatching() throws IOException {
+		Collection<AssetAdministrationShellDescriptor> found = getAllAasDescriptorsFiltered(AssetKind.TYPE, "A");
+		List<AssetAdministrationShellDescriptor> expected = testResourcesLoader.loadList(AssetAdministrationShellDescriptor.class);
+		assertThat(found).containsExactlyInAnyOrderElementsOf(expected);
+		verifyNoEventSent();
+	}
+	
+	@Test
+	public void whenGetAllAssetAdministrationShellDescriptorsFilteredNoKindButType_thenOnlyMatching() throws IOException, SerializationException {
+		Collection<AssetAdministrationShellDescriptor> found = getAllAasDescriptorsFiltered(null, "A");
+		List<AssetAdministrationShellDescriptor> expected = testResourcesLoader.loadList(AssetAdministrationShellDescriptor.class);
+		
+		System.out.println(new JsonSerializer().write(found));
+		assertThat(found).containsExactlyInAnyOrderElementsOf(expected);
+		verifyNoEventSent();
+	}
+	
+	@Test
+	public void whenGetAllAssetAdministrationShellDescriptorsFilteredNotApplicableAndType_thenOnlyMatching() throws IOException {
+		Collection<AssetAdministrationShellDescriptor> found = getAllAasDescriptorsFiltered(AssetKind.NOTAPPLICABLE, "A");
 		List<AssetAdministrationShellDescriptor> expected = testResourcesLoader.loadList(AssetAdministrationShellDescriptor.class);
 		assertThat(found).containsExactlyInAnyOrderElementsOf(expected);
 		verifyNoEventSent();

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByInstanceAndType_thenOnlyMatching.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByInstanceAndType_thenOnlyMatching.json
@@ -1,0 +1,7 @@
+[
+	{
+		"id": "identification_4",
+		"assetKind": "Instance",
+		"assetType": "A"
+	}  
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByInstanceAndType_thenOnlyMatching_repo.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByInstanceAndType_thenOnlyMatching_repo.json
@@ -1,0 +1,20 @@
+[
+	{
+		"id": "identification_1",
+		"assetKind": "Instance",
+		"assetType": "B"
+	},
+	{
+		"id": "identification_2",
+		"assetKind": "Type",
+		"assetType": "A"
+	}, 
+	{
+		"id": "identification_3"	 
+	}, 
+	{
+		"id": "identification_4",
+		"assetKind": "Instance",
+		"assetType": "A"
+	}  
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByTypeAndType_thenOnlyMatching.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByTypeAndType_thenOnlyMatching.json
@@ -1,0 +1,7 @@
+[
+	{
+		"id": "identification_2",
+		"assetKind": "Type",
+		"assetType": "A"
+	}
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByTypeAndType_thenOnlyMatching_repo.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredByTypeAndType_thenOnlyMatching_repo.json
@@ -1,0 +1,20 @@
+[
+	{
+		"id": "identification_1",
+		"assetKind": "Type",
+		"assetType": "B"
+	},
+	{
+		"id": "identification_2",
+		"assetKind": "Type",
+		"assetType": "A"
+	}, 
+	{
+		"id": "identification_3"	 
+	}, 
+	{
+		"id": "identification_4",
+		"assetKind": "Instance",
+		"assetType": "A"
+	}  
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNoKindButType_thenOnlyMatching.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNoKindButType_thenOnlyMatching.json
@@ -1,0 +1,16 @@
+[
+	{
+		"id": "identification_2",
+		"assetKind": "Type",
+		"assetType": "A"
+	}, 
+	{
+		"id": "identification_4",
+		"assetKind": "Instance",
+		"assetType": "A"
+	}, 
+	{
+		"id": "identification_7",
+		"assetType": "A"
+	}
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNoKindButType_thenOnlyMatching_repo.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNoKindButType_thenOnlyMatching_repo.json
@@ -1,0 +1,33 @@
+[
+	{
+		"id": "identification_1",
+		"assetKind": "Instance",
+		"assetType": "B"
+	},
+	{
+		"id": "identification_2",
+		"assetKind": "Type",
+		"assetType": "A"
+	}, 
+	{
+		"id": "identification_3"	 
+	}, 
+	{
+		"id": "identification_4",
+		"assetKind": "Instance",
+		"assetType": "A"
+	},  
+	{
+		"id": "identification_5",
+		"assetKind": "Type",
+		"assetType": "B"
+	},  
+	{
+		"id": "identification_6",
+		"assetType": "B"
+	}, 
+	{
+		"id": "identification_7",
+		"assetType": "A"
+	}
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNotApplicableAndType_thenOnlyMatching.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNotApplicableAndType_thenOnlyMatching.json
@@ -1,0 +1,6 @@
+[
+	{
+		"id": "identification_4",
+		"assetType": "A"
+	}  
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNotApplicableAndType_thenOnlyMatching_repo.json
+++ b/basyx.aasregistry/basyx.aasregistry-service-basetests/src/main/resources/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/whenGetAllAssetAdministrationShellDescriptorsFilteredNotApplicableAndType_thenOnlyMatching_repo.json
@@ -1,0 +1,18 @@
+[
+	{
+		"id": "identification_1",
+		"assetType": "B"
+	},
+	{
+		"id": "identification_2",
+		"assetKind": "Type",
+		"assetType": "A"
+	}, 
+	{
+		"id": "identification_3"	 
+	}, 
+	{
+		"id": "identification_4",
+		"assetType": "A"
+	}  
+]

--- a/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/memory/InMemoryAasRegistryStorage.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/memory/InMemoryAasRegistryStorage.java
@@ -250,26 +250,25 @@ public class InMemoryAasRegistryStorage implements AasRegistryStorage {
 		private final DescriptorFilter filter;
 
 		public boolean matches(AssetAdministrationShellDescriptor descr) {
-			AssetKind filterKind = filter.getKind();
-			AssetKind targetKind = descr.getAssetKind();
 
+			return matchesKind(filter.getKind(), descr.getAssetKind()) && matchesType(filter.getAssetType(), descr.getAssetType());
+		}
+
+		private boolean matchesKind(AssetKind filterKind, AssetKind descrKind) {
 			if (filterKind == null) {
 				return true;
 			}
-			if (filterKind == AssetKind.INSTANCE) {
-				return targetKind == AssetKind.INSTANCE;
-			} else if (filterKind == AssetKind.NOTAPPLICABLE) {
-				return targetKind == null;
-			} else if (targetKind != AssetKind.TYPE) {
-				return false;
-			} else {
-				String filterType = filter.getAssetType();
-				if (filterType == null) {
-					return true;
-				}
-				String targetType = descr.getAssetType();
-				return filterType.equals(targetType);
+			if (filterKind == AssetKind.NOTAPPLICABLE) {
+				return descrKind == null;
 			}
+			return filterKind == descrKind;
+		}
+
+		private boolean matchesType(String filterType, String descrType) {
+			if (filterType == null) {
+				return true;
+			}
+			return filterType.equals(descrType);
 		}
 	}
 

--- a/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/memory/PaginationSupport.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/memory/PaginationSupport.java
@@ -68,7 +68,7 @@ public class PaginationSupport<T extends Object> {
 
 
 	private Stream<Entry<String, T>> applyFilter(DescriptorFilter filter, Predicate<Entry<String, T>> filterMethod, Stream<Entry<String, T>> aStream) {
-		if (filter != null && filter.isFiltered()) {
+		if (filter != null) {
 			return aStream.filter(filterMethod);
 		}
 		return aStream;

--- a/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/memory/PaginationSupport.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-inmemory-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/memory/PaginationSupport.java
@@ -68,7 +68,7 @@ public class PaginationSupport<T extends Object> {
 
 
 	private Stream<Entry<String, T>> applyFilter(DescriptorFilter filter, Predicate<Entry<String, T>> filterMethod, Stream<Entry<String, T>> aStream) {
-		if (filter != null) {
+		if (filter != null && filter.isFiltered()) {
 			return aStream.filter(filterMethod);
 		}
 		return aStream;

--- a/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/DescriptorFilter.java
+++ b/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/DescriptorFilter.java
@@ -36,9 +36,5 @@ public class DescriptorFilter {
 	final AssetKind kind;
 	final String assetType;
 	
-	public boolean isFiltered() {
-		return kind != null;
-	}
 
-	
 }

--- a/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/DescriptorFilter.java
+++ b/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/storage/DescriptorFilter.java
@@ -36,5 +36,8 @@ public class DescriptorFilter {
 	final AssetKind kind;
 	final String assetType;
 	
+	public boolean isFiltered() {
+		return kind != null || assetType != null;
+	}
 
 }


### PR DESCRIPTION

# **Pull Request: Fix for Filtering in In-Memory AASRegistry**

## **Description of Changes**  
This pull request fixes the issue where the filtering of `assetType` and `assetKind` in the **in-memory variant of the AASRegistry** was not applied correctly. Previously:  
- When filtering with `assetKind=INSTANCE`, all Asset Administration Shells were returned, **ignoring the `assetType` filter**.  
- The `NOTAPPLICABLE` filter did not properly exclude entries that had an `assetKind` set.  

This fix ensures that:  
✅ `assetType` is **always** considered in the filtering process.  
✅ `assetKind=INSTANCE` returns **only** instances of that specific `assetType`.  
✅ `assetKind=NOTAPPLICABLE` **only** returns entries where `assetKind` is not set.  

---

## **Related Issue**  
Closes #659 

---

## **BaSyx Configuration for Testing**  
No specific BaSyx configuration changes are required for testing. The filtering logic is applied directly in the **in-memory variant of the AASRegistry**.

---

## **AAS Files Used for Testing**  
Standard AAS test data with various combinations of `assetType` and `assetKind` were used to validate the filtering behavior.  
- AAS with `assetKind=INSTANCE` and different `assetType` values.  
- AAS with `assetKind=NOTAPPLICABLE` to verify proper exclusion.  
- AAS with `assetKind=TYPE` and valid `assetType` filtering.  

---

## **Additional Information**  
- The previous implementation only applied the `assetType` filter when `assetKind=TYPE`, **ignoring it for `INSTANCE` and `NOTAPPLICABLE`**.  
- The new implementation cleanly separates filtering logic and ensures both `assetKind` and `assetType` are applied **independently but correctly**.  
- This has been tested against various cases to confirm correctness.  

---

✅ **Changes have been tested to ensure correct filtering behavior.**  
✅ **No breaking changes introduced.**  
✅ **Ready for review!**  

Let me know if you need any modifications before submitting! 🚀😊
