### PR TITLE
Feature/aas-env-ignore-duplicates

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
@@ -53,7 +53,7 @@ public interface AasEnvironment {
 
 	public byte[] createAASXAASEnvironmentSerialization(List<String> aasIds, List<String> submodelIds, boolean includeConceptDescriptions) throws SerializationException, IOException;
 
-	void loadEnvironment(CompleteEnvironment completeEnvironment, boolean overwrite);
+	void loadEnvironment(CompleteEnvironment completeEnvironment, boolean ignoreDuplicates);
 
 	default void loadEnvironment(CompleteEnvironment completeEnvironment){
 		loadEnvironment(completeEnvironment, false);

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
@@ -54,8 +54,5 @@ public interface AasEnvironment {
 	public byte[] createAASXAASEnvironmentSerialization(List<String> aasIds, List<String> submodelIds, boolean includeConceptDescriptions) throws SerializationException, IOException;
 
 	void loadEnvironment(CompleteEnvironment completeEnvironment, boolean ignoreDuplicates);
-
-	default void loadEnvironment(CompleteEnvironment completeEnvironment){
-		loadEnvironment(completeEnvironment, false);
-	}
+	void loadEnvironment(CompleteEnvironment completeEnvironment);
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
@@ -53,7 +53,8 @@ public interface AasEnvironment {
 
 	public byte[] createAASXAASEnvironmentSerialization(List<String> aasIds, List<String> submodelIds, boolean includeConceptDescriptions) throws SerializationException, IOException;
 
-	public void loadEnvironment(CompleteEnvironment completeEnvironment, boolean overwrite);
+	void loadEnvironment(CompleteEnvironment completeEnvironment, boolean overwrite);
+
 	default void loadEnvironment(CompleteEnvironment completeEnvironment){
 		loadEnvironment(completeEnvironment, false);
 	}

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/AasEnvironment.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (C) 2023 the Eclipse BaSyx Authors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -19,7 +19,7 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 package org.eclipse.digitaltwin.basyx.aasenvironment;
@@ -32,7 +32,7 @@ import org.eclipse.digitaltwin.basyx.aasenvironment.environmentloader.CompleteEn
 
 /**
  * Specifies the overall AasEnvironment API
- * 
+ *
  * @author zhangzai, danish
  *
  */
@@ -40,7 +40,7 @@ public interface AasEnvironment {
 
 	/**
 	 * Generate serialization from given aas and
-	 * 
+	 *
 	 * @param aasIds
 	 * @param submodelIds
 	 * @param includeConceptDescriptions
@@ -52,6 +52,9 @@ public interface AasEnvironment {
 	public String createXMLAASEnvironmentSerialization(List<String> aasIds, List<String> submodelIds, boolean includeConceptDescriptions) throws SerializationException;
 
 	public byte[] createAASXAASEnvironmentSerialization(List<String> aasIds, List<String> submodelIds, boolean includeConceptDescriptions) throws SerializationException, IOException;
-	
-	public void loadEnvironment(CompleteEnvironment completeEnvironment);
+
+	public void loadEnvironment(CompleteEnvironment completeEnvironment, boolean overwrite);
+	default void loadEnvironment(CompleteEnvironment completeEnvironment){
+		loadEnvironment(completeEnvironment, false);
+	}
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -155,6 +155,11 @@ public class DefaultAASEnvironment implements AasEnvironment {
 		createConceptDescriptionsOnRepositoryFromEnvironment(environment);
 	}
 
+	@Override
+	public void loadEnvironment(CompleteEnvironment completeEnvironment) {
+		loadEnvironment(completeEnvironment, false);
+	}
+
 	private void createConceptDescriptionsOnRepositoryFromEnvironment(Environment environment) {
 		IdentifiableRepository<ConceptDescription> repo = new DelegatingIdentifiableRepository<ConceptDescription>(conceptDescriptionRepository::getConceptDescription, conceptDescriptionRepository::updateConceptDescription,
 				conceptDescriptionRepository::createConceptDescription);

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -127,7 +127,7 @@ public class DefaultAASEnvironment implements AasEnvironment {
 			SubmodelElement submodelElement = stack.pop();
 
 			if (submodelElement instanceof File file) {
-                if(!isURL(file.getValue()))
+				if(!isURL(file.getValue()))
 					files.add(file);
 			} else if (submodelElement instanceof SubmodelElementCollection collection) {
 				stack.addAll(collection.getValue());
@@ -139,14 +139,16 @@ public class DefaultAASEnvironment implements AasEnvironment {
 		return files;
 	}
 
-	public void loadEnvironment(CompleteEnvironment completeEnvironment) {
+	public void loadEnvironment(CompleteEnvironment completeEnvironment, boolean overwrite) {
 		Environment environment = completeEnvironment.getEnvironment();
 		List<InMemoryFile> relatedFiles = completeEnvironment.getRelatedFiles();
 
 		if (environment == null)
 			return;
 
-		checker.assertNoDuplicateIds(environment);
+		if(!overwrite){
+			checker.assertNoDuplicateIds(environment);
+		}
 
 		createShellsOnRepositoryFromEnvironment(environment, relatedFiles);
 		createSubmodelsOnRepositoryFromEnvironment(environment, completeEnvironment.getRelatedFiles());
@@ -371,7 +373,7 @@ public class DefaultAASEnvironment implements AasEnvironment {
 				logger.error("Thumbnail file {} does not exist in the repository", thumbnail.getPath());
 			}
 		}
-    }
+	}
 
 	private static boolean isThumbnailSet(Resource thumbnail) {
 		return thumbnail != null && thumbnail.getPath() != null;
@@ -379,21 +381,21 @@ public class DefaultAASEnvironment implements AasEnvironment {
 
 	private static String getThumbnailPathInAASX(String path) {
 		try {
-            return "/" + getHashedFilePath(path) + "." + getFileExtensionFromPath(path);
-        } catch (NoSuchAlgorithmException e) {
+			return "/" + getHashedFilePath(path) + "." + getFileExtensionFromPath(path);
+		} catch (NoSuchAlgorithmException e) {
 			logger.error("Could not hash thumbnail path {}", path);
-            throw new RuntimeException(e);
-        }
-    }
+			throw new RuntimeException(e);
+		}
+	}
 
 	private static String getFilePathInAASX(String path) {
 		try {
-            return aasxFilePathPrefix + getHashedFilePath(path) + "." + getFileExtensionFromPath(path);
-        } catch (NoSuchAlgorithmException e) {
+			return aasxFilePathPrefix + getHashedFilePath(path) + "." + getFileExtensionFromPath(path);
+		} catch (NoSuchAlgorithmException e) {
 			logger.error("Could not hash file path {}", path);
-            throw new RuntimeException(e);
-        }
-    }
+			throw new RuntimeException(e);
+		}
+	}
 
 	private static String getFileExtensionFromPath(String file) {
 		String[] split = file.split("\\.");

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -139,14 +139,14 @@ public class DefaultAASEnvironment implements AasEnvironment {
 		return files;
 	}
 
-	public void loadEnvironment(CompleteEnvironment completeEnvironment, boolean overwrite) {
+	public void loadEnvironment(CompleteEnvironment completeEnvironment, boolean ignoreDuplicates) {
 		Environment environment = completeEnvironment.getEnvironment();
 		List<InMemoryFile> relatedFiles = completeEnvironment.getRelatedFiles();
 
 		if (environment == null)
 			return;
 
-		if(!overwrite){
+		if(!ignoreDuplicates){
 			checker.assertNoDuplicateIds(environment);
 		}
 

--- a/basyx.aasenvironment/basyx.aasenvironment-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/feature/authorization/AuthorizedAasEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/feature/authorization/AuthorizedAasEnvironment.java
@@ -82,21 +82,26 @@ public class AuthorizedAasEnvironment implements AasEnvironment {
 		
 		return decorated.createAASXAASEnvironmentSerialization(aasIds, submodelIds, includeConceptDescriptions);
 	}
-	
+
 	private void throwExceptionIfInsufficientPermission(boolean isAuthorized) {
 		if (!isAuthorized)
 			throw new InsufficientPermissionException("Insufficient Permission: The current subject does not have the required permissions for this operation.");
 	}
 
 	@Override
-	public void loadEnvironment(CompleteEnvironment completeEnvironment) {
+	public void loadEnvironment(CompleteEnvironment completeEnvironment, boolean ignoreDuplicates) {
 		Environment environment = completeEnvironment.getEnvironment();
 		
 		boolean isAuthorized = permissionResolver.hasPermission(Action.CREATE, new AasEnvironmentTargetInformation(getAasIds(environment.getAssetAdministrationShells()), getSubmodelIds(environment.getSubmodels())));
 		
 		throwExceptionIfInsufficientPermission(isAuthorized);
 		
-		decorated.loadEnvironment(completeEnvironment);
+		decorated.loadEnvironment(completeEnvironment, ignoreDuplicates);
+	}
+
+	@Override
+	public void loadEnvironment(CompleteEnvironment completeEnvironment) {
+		loadEnvironment(completeEnvironment, false);
 	}
 
 	private List<String> getSubmodelIds(List<Submodel> submodels) {

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AASEnvironmentHTTPApi.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AASEnvironmentHTTPApi.java
@@ -76,5 +76,9 @@ public interface AASEnvironmentHTTPApi {
 			@ApiResponse(responseCode = "400", description = "Bad Request, invalid file format or structure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class))),
 			@ApiResponse(responseCode = "500", description = "Internal Server Error, processing failure", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class))) })
 	@RequestMapping(value = "/upload", method = RequestMethod.POST)
-	ResponseEntity<Boolean> uploadEnvironment(@Parameter(description = "An environment file (XML, JSON, AASX)") @Valid @RequestParam("file") MultipartFile envFile);
+	ResponseEntity<Boolean> uploadEnvironment(
+			@Parameter(description = "An environment file (XML, JSON, AASX)") @Valid @RequestParam("file") MultipartFile envFile,
+			@Parameter(description = "Flag to indicate if existing environment should be overwritten (default: false)", schema = @Schema(defaultValue = "false"))
+			@RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite
+	);
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AASEnvironmentHTTPApi.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AASEnvironmentHTTPApi.java
@@ -78,7 +78,7 @@ public interface AASEnvironmentHTTPApi {
 	@RequestMapping(value = "/upload", method = RequestMethod.POST)
 	ResponseEntity<Boolean> uploadEnvironment(
 			@Parameter(description = "An environment file (XML, JSON, AASX)") @Valid @RequestParam("file") MultipartFile envFile,
-			@Parameter(description = "Flag to indicate if existing environment should be overwritten (default: false)", schema = @Schema(defaultValue = "false"))
-			@RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite
+			@Parameter(description = "Flag to indicate if already existing Ids should be ignored when reuploading an environment (default: false)", schema = @Schema(defaultValue = "false"))
+			@RequestParam(value = "ignore-duplicates", required = false, defaultValue = "false") boolean ignoreDuplicates
 	);
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AasEnvironmentApiHTTPController.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AasEnvironmentApiHTTPController.java
@@ -102,40 +102,42 @@ public class AasEnvironmentApiHTTPController implements AASEnvironmentHTTPApi {
 	}
 
 	@Override
-	public ResponseEntity<Boolean> uploadEnvironment(MultipartFile envFile) {
+	public ResponseEntity<Boolean> uploadEnvironment(
+			@RequestParam(value = "file") MultipartFile envFile,
+			@RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite) {
 		try {
 			EnvironmentType envType = EnvironmentType.getFromMimeType(envFile.getContentType());
 
 			if (envType == null)
 				envType = EnvironmentType.AASX;
 
-			aasEnvironment.loadEnvironment(CompleteEnvironment.fromInputStream(envFile.getInputStream(), envType));
+			aasEnvironment.loadEnvironment(CompleteEnvironment.fromInputStream(envFile.getInputStream(), envType), overwrite);
 
 		} catch (InvalidFormatException e) {
-			return new ResponseEntity<Boolean>(false, HttpStatus.BAD_REQUEST);
+			return new ResponseEntity<>(false, HttpStatus.BAD_REQUEST);
 		} catch (DeserializationException | IOException e) {
-			return new ResponseEntity<Boolean>(false, HttpStatus.INTERNAL_SERVER_ERROR);
+			return new ResponseEntity<>(false, HttpStatus.INTERNAL_SERVER_ERROR);
 		}
-		return new ResponseEntity<Boolean>(true, HttpStatus.OK);
+		return new ResponseEntity<>(true, HttpStatus.OK);
 	}
 
 	private List<String> getOriginalIds(List<String> ids) {
 		List<String> results = new ArrayList<>();
-		
+
 		if (!areValidIds(ids))
 			return results;
-		
+
 		ids.forEach(id -> {
 			results.add(Base64UrlEncodedIdentifier.fromEncodedValue(id).getIdentifier());
 		});
-		
+
 		return results;
 	}
 
 	private boolean areParametersValid(String accept, @Valid List<String> aasIds, @Valid List<String> submodelIds) {
 		if (!areValidIds(aasIds) && !areValidIds(submodelIds))
 			return false;
-		
+
 		return (accept.equals(ACCEPT_AASX) || accept.equals(ACCEPT_JSON) || accept.equals(ACCEPT_XML));
 	}
 

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AasEnvironmentApiHTTPController.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/http/AasEnvironmentApiHTTPController.java
@@ -104,14 +104,15 @@ public class AasEnvironmentApiHTTPController implements AASEnvironmentHTTPApi {
 	@Override
 	public ResponseEntity<Boolean> uploadEnvironment(
 			@RequestParam(value = "file") MultipartFile envFile,
-			@RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite) {
+			@RequestParam(value = "ignore-duplicates", required = false, defaultValue = "false") boolean ignoreDuplicates) {
 		try {
 			EnvironmentType envType = EnvironmentType.getFromMimeType(envFile.getContentType());
 
 			if (envType == null)
 				envType = EnvironmentType.AASX;
 
-			aasEnvironment.loadEnvironment(CompleteEnvironment.fromInputStream(envFile.getInputStream(), envType), overwrite);
+			aasEnvironment.loadEnvironment(CompleteEnvironment.fromInputStream(envFile.getInputStream(), envType),
+					ignoreDuplicates);
 
 		} catch (InvalidFormatException e) {
 			return new ResponseEntity<>(false, HttpStatus.BAD_REQUEST);

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP.java
@@ -70,11 +70,11 @@ public class TestAasEnvironmentHTTP {
 	public static final String AASX_MIMETYPE = "application/asset-administration-shell-package+xml";
 
 	public static final String AASX_ENV_PATH = "testEnvironment.aasx";
-	private static final String JSON_ENV_PATH = "testEnvironment.json";
+	static final String JSON_ENV_PATH = "testEnvironment.json";
 	private static final String XML_ENV_PATH = "testEnvironment.xml";
 	private static final String WRONGEXT_ENV_PATH = "testEnvironment.txt";
-	private static final String JSON_OPERATIONALDATA_ENV_PATH = "operationalDataEnvironment.json";
-	private static final String AASENVIRONMENT_VALUE_ONLY_JSON = "AASEnvironmentValueOnly.json";
+	static final String JSON_OPERATIONALDATA_ENV_PATH = "operationalDataEnvironment.json";
+	static final String AASENVIRONMENT_VALUE_ONLY_JSON = "AASEnvironmentValueOnly.json";
 
 	private static ConfigurableApplicationContext appContext;
 	private static SubmodelRepository submodelRepo;
@@ -277,18 +277,22 @@ public class TestAasEnvironmentHTTP {
 		return aasCreateRequest;
 	}
 
-	private static HttpPost createPostRequestWithFile(String filepath, String contentType) throws FileNotFoundException {
+	static HttpPost createPostRequestWithFile(String filepath, String contentType, boolean overwrite) throws FileNotFoundException {
 		java.io.File file = ResourceUtils.getFile("classpath:" + filepath);
 
-		return BaSyxHttpTestUtils.createPostRequestWithFile(getAASXUploadURL(), file, contentType);
+		return BaSyxHttpTestUtils.createPostRequestWithFile(getAASXUploadURL(overwrite), file, contentType);
+	}
+
+	static HttpPost createPostRequestWithFile(String filepath, String contentType) throws FileNotFoundException {
+		return createPostRequestWithFile(filepath, contentType, false);
 	}
 
 	public static String getURL() {
 		return "http://localhost:8081";
 	}
 
-	private static String getAASXUploadURL() {
-		return getURL() + "/upload";
+	private static String getAASXUploadURL(boolean overwrite) {
+		return getURL() + "/upload?overwrite="+overwrite;
 	}
 
 	public static String getOperationalDataValueOnlyURL() {

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP.java
@@ -277,10 +277,10 @@ public class TestAasEnvironmentHTTP {
 		return aasCreateRequest;
 	}
 
-	static HttpPost createPostRequestWithFile(String filepath, String contentType, boolean overwrite) throws FileNotFoundException {
+	static HttpPost createPostRequestWithFile(String filepath, String contentType, boolean ignoreDuplicates) throws FileNotFoundException {
 		java.io.File file = ResourceUtils.getFile("classpath:" + filepath);
 
-		return BaSyxHttpTestUtils.createPostRequestWithFile(getAASXUploadURL(overwrite), file, contentType);
+		return BaSyxHttpTestUtils.createPostRequestWithFile(getAASXUploadURL(ignoreDuplicates), file, contentType);
 	}
 
 	static HttpPost createPostRequestWithFile(String filepath, String contentType) throws FileNotFoundException {
@@ -291,8 +291,8 @@ public class TestAasEnvironmentHTTP {
 		return "http://localhost:8081";
 	}
 
-	private static String getAASXUploadURL(boolean overwrite) {
-		return getURL() + "/upload?overwrite="+overwrite;
+	private static String getAASXUploadURL(boolean ignoreDuplicates) {
+		return getURL() + "/upload?ignore-duplicates="+ignoreDuplicates;
 	}
 
 	public static String getOperationalDataValueOnlyURL() {

--- a/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP_OverwriteEnv.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-http/src/test/java/org/eclipse/basyx/digitaltwin/aasenvironment/http/TestAasEnvironmentHTTP_OverwriteEnv.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.basyx.digitaltwin.aasenvironment.http;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import org.eclipse.digitaltwin.basyx.aasenvironment.TestAASEnvironmentSerialization;
+import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
+import org.eclipse.digitaltwin.basyx.conceptdescriptionrepository.ConceptDescriptionRepository;
+import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
+import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifier;
+import org.eclipse.digitaltwin.basyx.http.HttpBaSyxHeader;
+import org.eclipse.digitaltwin.basyx.http.serialization.BaSyxHttpTestUtils;
+import org.eclipse.digitaltwin.basyx.submodelrepository.SubmodelRepository;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.ResourceUtils;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.eclipse.basyx.digitaltwin.aasenvironment.http.TestAasEnvironmentHTTP.*;
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class TestAasEnvironmentHTTP_OverwriteEnv {
+
+
+	private static ConfigurableApplicationContext appContext;
+	private static SubmodelRepository submodelRepo;
+	private static AasRepository aasRepo;
+	private static ConceptDescriptionRepository conceptDescriptionRepo;
+
+	private static final String AAS_ID = "http://customer.com/aas/9175_7013_7091_9168";
+	private static final String SUBMODEL_ID = "http://i40.customer.com/type/1/1/7A7104BDAB57E184";
+	private static final String CONCEPT_DESCRIPTION_ID = "http://www.vdi2770.com/blatt1/Entwurf/Okt18/cd/Description/Title";
+
+	private int initialAasCount;
+	private int initialSmCount;
+	private int initialCdCount;
+
+
+	@BeforeClass
+	public static void startAasRepo() throws Exception {
+		appContext = new SpringApplication(DummyAASEnvironmentComponent.class).run(new String[] {});
+		submodelRepo = appContext.getBean(SubmodelRepository.class);
+		aasRepo = appContext.getBean(AasRepository.class);
+		conceptDescriptionRepo = appContext.getBean(ConceptDescriptionRepository.class);
+	}
+
+	@Parameterized.Parameter
+	public String scenario;
+
+	@Parameters(name = "TestCase: {0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{ "NO_CHANGE" },    // Normal overwrite test
+				{ "DELETE_AAS" },   // Delete AAS before overwriting
+				{ "DELETE_SM" },    // Delete Submodel before overwriting
+				{ "DELETE_CD" }     // Delete ConceptDescription before overwriting
+		});
+	}
+
+
+	@Test
+	public void testEnvironmentOverwrite_AASX() throws IOException {
+		uploadInitialAASX();
+		recordInitialCounts();
+
+		applyScenarioModifications();
+
+		overwriteAASX();
+		verifyFinalState();
+
+		cleanEnvironment();
+	}
+
+	private void uploadInitialAASX() throws IOException {
+		CloseableHttpResponse response = BaSyxHttpTestUtils.executePostRequest(
+				HttpClients.createDefault(),
+				createPostRequestWithFile(AASX_ENV_PATH, AASX_MIMETYPE));
+
+		assertEquals(HttpStatus.OK.value(), response.getCode());
+		assertEntitiesExist();
+	}
+
+	private void recordInitialCounts() {
+		initialAasCount = aasRepo.getAllAas(PaginationInfo.NO_LIMIT).getResult().size();
+		initialSmCount = submodelRepo.getAllSubmodels(PaginationInfo.NO_LIMIT).getResult().size();
+		initialCdCount = conceptDescriptionRepo.getAllConceptDescriptions(PaginationInfo.NO_LIMIT).getResult().size();
+	}
+
+	private void applyScenarioModifications() {
+		switch (scenario) {
+		case "DELETE_AAS":
+			deleteAas();
+			break;
+		case "DELETE_SM":
+			deleteSubmodel();
+			break;
+		case "DELETE_CD":
+			deleteConceptDescription();
+			break;
+		default:
+			break; // NO_CHANGE scenario
+		}
+	}
+
+	private void deleteAas() {
+		aasRepo.deleteAas(AAS_ID);
+		assertThrows(ElementDoesNotExistException.class, () -> aasRepo.getAas(AAS_ID));
+		assertEquals(initialAasCount - 1, aasRepo.getAllAas(PaginationInfo.NO_LIMIT).getResult().size());
+	}
+
+	private void deleteSubmodel() {
+		submodelRepo.deleteSubmodel(SUBMODEL_ID);
+		assertThrows(ElementDoesNotExistException.class, () -> submodelRepo.getSubmodel(SUBMODEL_ID));
+		assertEquals(initialSmCount - 1, submodelRepo.getAllSubmodels(PaginationInfo.NO_LIMIT).getResult().size());
+	}
+
+	private void deleteConceptDescription() {
+		conceptDescriptionRepo.deleteConceptDescription(CONCEPT_DESCRIPTION_ID);
+		assertThrows(ElementDoesNotExistException.class, () -> conceptDescriptionRepo.getConceptDescription(CONCEPT_DESCRIPTION_ID));
+		assertEquals(initialCdCount - 1, conceptDescriptionRepo.getAllConceptDescriptions(PaginationInfo.NO_LIMIT).getResult().size());
+	}
+
+	private void overwriteAASX() throws IOException {
+		CloseableHttpResponse response = BaSyxHttpTestUtils.executePostRequest(
+				HttpClients.createDefault(),
+				createPostRequestWithFile(AASX_ENV_PATH, AASX_MIMETYPE, true));
+
+		assertEquals(HttpStatus.OK.value(), response.getCode());
+		assertEntitiesExist();
+	}
+
+	private void verifyFinalState() {
+		assertEquals(initialAasCount, aasRepo.getAllAas(PaginationInfo.NO_LIMIT).getResult().size());
+		assertEquals(initialSmCount, submodelRepo.getAllSubmodels(PaginationInfo.NO_LIMIT).getResult().size());
+		assertEquals(initialCdCount, conceptDescriptionRepo.getAllConceptDescriptions(PaginationInfo.NO_LIMIT).getResult().size());
+	}
+
+	private void assertEntitiesExist() {
+		assertNotNull(aasRepo.getAas(AAS_ID));
+		assertNotNull(submodelRepo.getSubmodel(SUBMODEL_ID));
+		assertNotNull(conceptDescriptionRepo.getConceptDescription(CONCEPT_DESCRIPTION_ID));
+	}
+
+	private void cleanEnvironment() {
+		try {
+			submodelRepo.deleteSubmodel(SUBMODEL_ID);
+			aasRepo.deleteAas(AAS_ID);
+			conceptDescriptionRepo.deleteConceptDescription(CONCEPT_DESCRIPTION_ID);
+		} catch (Exception ignored) {}
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		appContext.close();
+	}
+}


### PR DESCRIPTION
## Description of Changes

A new request parameter named 'ignore-duplicates' has been added to the 'uploadEnvironment' method of the 'AASEnvironmentHTTPApi' interface. This ensures that existing IDs of the environment to be uploaded are ignored if they already exist. Previously, it was not possible to re-upload the same environment.

## BaSyx Configuration for Testing

No special configuration necessary. The corresponding tests are in 'TestAasEnvironmentHTTP_IgnoreDuplicates'.

## AAS Files Used for Testing

The AASX files used are already part of the test suite.
