### PR TITLE
Fixes workflow for testing javadoc

### DIFF
--- a/.github/workflows/test-javadoc.yml
+++ b/.github/workflows/test-javadoc.yml
@@ -33,7 +33,5 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           cache: maven
-      - name: BaSyx Clean Install
-        run: mvn clean install -Dmaven.test.skip=true -T1C
       - name: Validate Javadoc
-        run: mvn clean javadoc:javadoc
+        run: mvn package -DskipTests javadoc:javadoc


### PR DESCRIPTION
## Description of Changes

This fixes a problem where the javadoc workflow fails for the registries since a mvn package is needed to trigger the right lifecycle phase so that all dependencies are present