### PR TITLE
fix: set correct mount for aas discovery application properties in helm chart

### DIFF
--- a/examples/cloud/dependency_charts/aas-discovery/templates/aas-discovery-deployment.yaml
+++ b/examples/cloud/dependency_charts/aas-discovery/templates/aas-discovery-deployment.yaml
@@ -32,7 +32,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           volumeMounts:
-            - mountPath: /workspace/config/application.properties
+            - mountPath: /application/application.properties
               name: {{ template "aas-discovery.fullname" $ }}-config
               subPath: application.properties
             - mountPath: /application/rbac-rules.json


### PR DESCRIPTION
fixed incorrect mount for aas discovery application properties in helm chart