### PR TITLE
Adds Transactional to Delete SME

### DIFF
--- a/basyx.submodelservice/basyx.submodelservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/MongoDbSubmodelOperations.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/MongoDbSubmodelOperations.java
@@ -55,6 +55,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
 import com.mongodb.client.result.UpdateResult;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * MongoDb implementation of the {@link SubmodelOperations}
@@ -180,6 +181,7 @@ public class MongoDbSubmodelOperations implements SubmodelOperations {
     }
 
     @Override
+    @Transactional
     public synchronized void deleteSubmodelElement(String submodelId, String idShortPath) throws ElementDoesNotExistException {
 
         Submodel submodel = getSubmodel(submodelId);


### PR DESCRIPTION
## Description of Changes

Adds Transactional Annotation to Delete SME Method in MongoDbSubmodelOperations

## Related Issue

## BaSyx Configuration for Testing


## AAS Files Used for Testing


## Additional Information

