### PR TITLE
Fixes SetFileValue Bug with MongoDB Backend

### DIFF
--- a/basyx.common/basyx.filerepository-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/core/filerepository/MongoDBFileRepository.java
+++ b/basyx.common/basyx.filerepository-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/core/filerepository/MongoDBFileRepository.java
@@ -100,6 +100,8 @@ public class MongoDBFileRepository implements FileRepository {
 	@Override
 	public boolean exists(String fileName) {
 
+		if(fileName == null) return false;
+
 		if (fileName.isBlank())
 			return false;
 


### PR DESCRIPTION
## Description of Changes

This PR fixes a Bug where the SetFileValue Endpoint did not work when using MongoDB as a backend.

## Related Issue
closes #531 

## BaSyx Configuration for Testing

## AAS Files Used for Testing

## Additional Information

