### PR TITLE
Fixes a error in the assetIds Query Parameter of the /shells endpoint

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository-http/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/http/AasRepositoryHTTPSuite.java
+++ b/basyx.aasrepository/basyx.aasrepository-http/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/http/AasRepositoryHTTPSuite.java
@@ -193,6 +193,16 @@ public abstract class AasRepositoryHTTPSuite {
 	}
 
 	@Test
+	public void getAllAasWithMultipleAssetIds() throws IOException, ParseException {
+		createMultipleAasOnServer();
+		CloseableHttpResponse retrievalResponse = getAllAasMultipleGlobalAssetIdsParam();
+		assertEquals(HttpStatus.OK.value(), retrievalResponse.getCode());
+
+		String actualJsonFromServer = BaSyxHttpTestUtils.getResponseAsString(retrievalResponse);
+		BaSyxHttpTestUtils.assertSameJSONContent(getEmptyResultJSONString(), getJSONWithoutCursorInfo(actualJsonFromServer));
+	}
+
+	@Test
 	public void deleteAas() throws IOException {
 		createDummyAasOnServer(getAas1JSONString());
 
@@ -423,6 +433,10 @@ public abstract class AasRepositoryHTTPSuite {
 	private String getPaginatedAas1JSONString() throws FileNotFoundException, IOException {
 		return BaSyxHttpTestUtils.readJSONStringFromClasspath("PaginatedAasSimple_1.json");
 	}
+
+	private String getEmptyResultJSONString() throws FileNotFoundException, IOException {
+		return BaSyxHttpTestUtils.readJSONStringFromClasspath("EmptyResponse.json");
+	}
 	
 	private String getJSONWithoutCursorInfo(String response) throws JsonMappingException, JsonProcessingException {
 		return BaSyxHttpTestUtils.removeCursorFromJSON(response);
@@ -487,6 +501,10 @@ public abstract class AasRepositoryHTTPSuite {
 
 	protected CloseableHttpResponse getAllAasGlobalAssetIdsParam() throws IOException {
 		return BaSyxHttpTestUtils.executeGetOnURL(getURL()+"?assetIds=ew0KIm5hbWUiOiJnbG9iYWxBc3NldElkIiwNCiJ2YWx1ZSI6Imdsb2JhbEFzc2V0SWQiDQp9");
+	}
+
+	protected CloseableHttpResponse getAllAasMultipleGlobalAssetIdsParam() throws IOException {
+		return BaSyxHttpTestUtils.executeGetOnURL(getURL()+"?assetIds=ew0KIm5hbWUiOiJnbG9iYWxBc3NldElkIiwNCiJ2YWx1ZSI6Imdsb2JhbEFzc2V0SWQiDQp9&assetIds=ew0KIm5hbWUiOiJnbG9iYWxBc3NldElkIiwNCiJ2YWx1ZSI6ImR1bW15QWFzQXNzZXRJZCINCn0");
 	}
 
 	protected CloseableHttpResponse getAllAasIdShortParam() throws IOException {

--- a/basyx.aasrepository/basyx.aasrepository-http/src/test/resources/EmptyResponse.json
+++ b/basyx.aasrepository/basyx.aasrepository-http/src/test/resources/EmptyResponse.json
@@ -1,0 +1,5 @@
+{
+  "paging_metadata": {},
+  "result": [
+  ]
+}

--- a/basyx.aasservice/basyx.aasservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/InMemoryAasBackend.java
+++ b/basyx.aasservice/basyx.aasservice-backend-inmemory/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/InMemoryAasBackend.java
@@ -104,6 +104,9 @@ public class InMemoryAasBackend extends InMemoryCrudRepository<AssetAdministrati
 		List<AssetAdministrationShell> filteredAas = new java.util.ArrayList<>();
 		String globalAssetId = null;
 		try {
+			if(assetIds.stream().filter(assetId -> assetId.getName().equals("globalAssetId")).count() > 1){
+				return filteredAas;
+			}
 			globalAssetId = assetIds.stream().filter(assetId -> assetId.getName().equals("globalAssetId")).findFirst().get().getValue();
 			assetIds = assetIds.stream().filter(assetId -> !assetId.getName().equals("globalAssetId")).collect(Collectors.toList());
 		} catch (Exception e) {}

--- a/basyx.aasservice/basyx.aasservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/MongoDBAasOperations.java
+++ b/basyx.aasservice/basyx.aasservice-backend-mongodb/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/MongoDBAasOperations.java
@@ -176,12 +176,10 @@ public class MongoDBAasOperations implements AasOperations {
         Query query = new Query();
         Criteria criteria = new Criteria();
 
-        String globalAssetId = null;
-        try {
-            globalAssetId = assetIds.stream().filter(assetId -> assetId.getName().equals("globalAssetId")).findFirst().get().getValue();
-            assetIds = assetIds.stream().filter(assetId -> !assetId.getName().equals("globalAssetId")).collect(Collectors.toList());
-        } catch (Exception ignored) {}
-
+        List<String> globalAssetId = assetIds.stream()
+                .filter(assetId -> "globalAssetId".equals(assetId.getName()))
+                .map(SpecificAssetId::getValue)
+                .collect(Collectors.toList());
         if (assetIds != null && !assetIds.isEmpty()) {
             List<Criteria> assetIdCriteria = new ArrayList<>();
             for (SpecificAssetId assetId : assetIds) {
@@ -195,8 +193,8 @@ public class MongoDBAasOperations implements AasOperations {
         }
         query.addCriteria(criteria);
 
-        if (globalAssetId != null && !globalAssetId.isEmpty()) {
-            query.addCriteria(Criteria.where("assetInformation.globalAssetId").is(globalAssetId));
+        for (String id : globalAssetId) {
+            query.addCriteria(Criteria.where("assetInformation.globalAssetId").is(id));
         }
 
         return mongoOperations.find(query, AssetAdministrationShell.class, collectionName);


### PR DESCRIPTION
## Description of Changes

This PR Fixes a error in the assetIds Query Parameter of the /shells endpoint where it was possible to specify a 2nd globalAssetId that got ignored

## Related Issue

## BaSyx Configuration for Testing


## AAS Files Used for Testing


## Additional Information


