### PR TITLE
Replaces usage of ofInputStream with ofString in clients where applicable

### DIFF
--- a/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/client/internal/AssetAdministrationShellDiscoveryApi.java
+++ b/basyx.aasdiscoveryservice/basyx.aasdiscoveryservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasdiscoveryservice/client/internal/AssetAdministrationShellDiscoveryApi.java
@@ -25,7 +25,6 @@
 package org.eclipse.digitaltwin.basyx.aasdiscoveryservice.client.internal;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -63,8 +62,6 @@ public class AssetAdministrationShellDiscoveryApi {
     private final String baseUri;
     private final Consumer<HttpRequest.Builder> requestInterceptor;
     private final Duration readTimeout;
-    private final Consumer<HttpResponse<InputStream>> responseInterceptor;
-    private final Consumer<HttpResponse<String>> asyncResponseInterceptor;
     private TokenManager tokenManager;
 
     public AssetAdministrationShellDiscoveryApi() {
@@ -82,8 +79,6 @@ public class AssetAdministrationShellDiscoveryApi {
         this.baseUri = apiClient.getBaseUri();
         this.requestInterceptor = apiClient.getRequestInterceptor();
         this.readTimeout = apiClient.getReadTimeout();
-        this.responseInterceptor = apiClient.getResponseInterceptor();
-        this.asyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
     }
 
     public AssetAdministrationShellDiscoveryApi(String baseUri) {
@@ -103,9 +98,11 @@ public class AssetAdministrationShellDiscoveryApi {
     public ApiResponse<Base64UrlEncodedCursorResult<List<String>>> getAllAssetAdministrationShellIdsByAssetLinkWithHttpInfo(List<AssetLink> assetIds, Integer limit, String cursor) throws ApiException {
         HttpRequest.Builder requestBuilder = getAllShellIdsRequestBuilder(assetIds, limit, cursor);
         try {
-            HttpResponse<InputStream> response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-            if (responseInterceptor != null) responseInterceptor.accept(response);
-            if (response.statusCode() / 100 != 2) throw getApiException("getAllAssetAdministrationShellIdsByAssetLink", response);
+			HttpResponse<String> response = httpClient.send(requestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+				throw getApiException("getAllAssetAdministrationShellIdsByAssetLink", response);
+			}
             return new ApiResponse<>(
                     response.statusCode(),
                     response.headers().map(),
@@ -136,14 +133,20 @@ public class AssetAdministrationShellDiscoveryApi {
         queryParams.addAll(ApiClient.parameterToPairs("cursor", cursor));
 
         StringJoiner query = new StringJoiner("&");
-        for (Pair p : queryParams) query.add(p.getName() + "=" + p.getValue());
+        for (Pair p : queryParams) {
+			query.add(p.getName() + "=" + p.getValue());
+		}
 
         builder.uri(URI.create(baseUri + path + (query.length() > 0 ? "?" + query : "")));
         builder.header("Accept", "application/json");
         addAuthorizationHeaderIfAuthIsEnabled(builder);
         builder.method("GET", HttpRequest.BodyPublishers.noBody());
-        if (readTimeout != null) builder.timeout(readTimeout);
-        if (requestInterceptor != null) requestInterceptor.accept(builder);
+        if (readTimeout != null) {
+			builder.timeout(readTimeout);
+		}
+        if (requestInterceptor != null) {
+			requestInterceptor.accept(builder);
+		}
         return builder;
     }
 
@@ -153,14 +156,18 @@ public class AssetAdministrationShellDiscoveryApi {
         builder.header("Accept", "application/json");
         addAuthorizationHeaderIfAuthIsEnabled(builder);
         builder.method("GET", HttpRequest.BodyPublishers.noBody());
-        if (readTimeout != null) builder.timeout(readTimeout);
-        if (requestInterceptor != null) requestInterceptor.accept(builder);
+        if (readTimeout != null) {
+			builder.timeout(readTimeout);
+		}
+        if (requestInterceptor != null) {
+			requestInterceptor.accept(builder);
+		}
 
         try {
-            HttpResponse<InputStream> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream());
-            if (responseInterceptor != null) responseInterceptor.accept(response);
-            if (response.statusCode() / 100 != 2)
-                throw getApiException("getAllAssetLinksById", response);
+			HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+				throw getApiException("getAllAssetLinksById", response);
+			}
             return objectMapper.readValue(response.body(), new TypeReference<List<SpecificAssetId>>() {});
         } catch (IOException | InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -182,14 +189,18 @@ public class AssetAdministrationShellDiscoveryApi {
             throw new ApiException(e);
         }
 
-        if (readTimeout != null) builder.timeout(readTimeout);
-        if (requestInterceptor != null) requestInterceptor.accept(builder);
+        if (readTimeout != null) {
+			builder.timeout(readTimeout);
+		}
+        if (requestInterceptor != null) {
+			requestInterceptor.accept(builder);
+		}
 
         try {
-            HttpResponse<InputStream> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream());
-            if (responseInterceptor != null) responseInterceptor.accept(response);
-            if (response.statusCode() / 100 != 2)
-                throw getApiException("postAllAssetLinksById", response);
+			HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+				throw getApiException("postAllAssetLinksById", response);
+			}
             return objectMapper.readValue(response.body(), new TypeReference<List<SpecificAssetId>>() {});
         } catch (IOException | InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -203,14 +214,18 @@ public class AssetAdministrationShellDiscoveryApi {
         builder.header("Accept", "application/json");
         addAuthorizationHeaderIfAuthIsEnabled(builder);
         builder.method("DELETE", HttpRequest.BodyPublishers.noBody());
-        if (readTimeout != null) builder.timeout(readTimeout);
-        if (requestInterceptor != null) requestInterceptor.accept(builder);
+        if (readTimeout != null) {
+			builder.timeout(readTimeout);
+		}
+        if (requestInterceptor != null) {
+			requestInterceptor.accept(builder);
+		}
 
         try {
-            HttpResponse<InputStream> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream());
-            if (responseInterceptor != null) responseInterceptor.accept(response);
-            if (response.statusCode() / 100 != 2)
-                throw getApiException("deleteAllAssetLinksById", response);
+			HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+				throw getApiException("deleteAllAssetLinksById", response);
+			}
         } catch (IOException | InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new ApiException(e);
@@ -223,14 +238,18 @@ public class AssetAdministrationShellDiscoveryApi {
         builder.header("Accept", "application/json");
         addAuthorizationHeaderIfAuthIsEnabled(builder);
         builder.method("GET", HttpRequest.BodyPublishers.noBody());
-        if (readTimeout != null) builder.timeout(readTimeout);
-        if (requestInterceptor != null) requestInterceptor.accept(builder);
+        if (readTimeout != null) {
+			builder.timeout(readTimeout);
+		}
+        if (requestInterceptor != null) {
+			requestInterceptor.accept(builder);
+		}
 
         try {
-            HttpResponse<InputStream> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream());
-            if (responseInterceptor != null) responseInterceptor.accept(response);
-            if (response.statusCode() / 100 != 2)
-                throw getApiException("getDescription", response);
+			HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+				throw getApiException("getDescription", response);
+			}
             return objectMapper.readValue(response.body(), Object.class);
         } catch (IOException | InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -238,9 +257,10 @@ public class AssetAdministrationShellDiscoveryApi {
         }
     }
 
-    private ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-        String body = response.body() == null ? null : new String(response.body().readAllBytes());
-        return new ApiException(response.statusCode(), operationId + " call failed with: " + response.statusCode() + " - " + (body != null ? body : "[no body]"), response.headers(), body);
+	private ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+		return new ApiException(response.statusCode(),
+				operationId + " call failed with: " + response.statusCode() + " - " + response.body(),
+				response.headers(), response.body());
     }
 
     private void addAuthorizationHeaderIfAuthIsEnabled(HttpRequest.Builder builder) {

--- a/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/internal/SerializationApi.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-client/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/client/internal/SerializationApi.java
@@ -44,10 +44,8 @@ import org.eclipse.digitaltwin.basyx.client.internal.authorization.TokenManager;
 import org.eclipse.digitaltwin.basyx.core.exceptions.AccessTokenRetrievalException;
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncodedIdentifier;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-12-02T23:26:18.943744+01:00[Europe/Berlin]")
@@ -103,10 +101,10 @@ public class SerializationApi {
     memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
   }
 
-  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    String message = formatExceptionMessage(operationId, response.statusCode(), body);
-    return new ApiException(response.statusCode(), message, response.headers(), body);
+	protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
+		String body = response.body() == null ? null : new String(response.body().readAllBytes());
+		String message = formatExceptionMessage(operationId, response.statusCode(), body);
+		return new ApiException(response.statusCode(), message, response.headers(), body);
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {

--- a/basyx.aasregistry/basyx.aasregistry-client-native/templates/libraries/native/api.mustache
+++ b/basyx.aasregistry/basyx.aasregistry-client-native/templates/libraries/native/api.mustache
@@ -59,8 +59,6 @@ public class {{classname}} {
   private final String memberVarBaseUri;
   private final {{#fullJavaUtil}}java.util.function.{{/fullJavaUtil}}Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-  private final {{#fullJavaUtil}}java.util.function.{{/fullJavaUtil}}Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  private final {{#fullJavaUtil}}java.util.function.{{/fullJavaUtil}}Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
   private TokenManager tokenManager;
 
   public {{classname}}() {
@@ -101,8 +99,6 @@ public class {{classname}} {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
-    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
-    memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
   }
   {{#asyncNative}}
 
@@ -113,10 +109,9 @@ public class {{classname}} {
   {{/asyncNative}}
   {{^asyncNative}}
 
-  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    String message = formatExceptionMessage(operationId, response.statusCode(), body);
-    return new ApiException(response.statusCode(), message, response.headers(), body);
+  protected ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
   {{/asyncNative}}
 
@@ -273,12 +268,9 @@ public class {{classname}} {
     {{^asyncNative}}
     HttpRequest.Builder localVarRequestBuilder = {{operationId}}RequestBuilder({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+      HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+          HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("{{operationId}}", localVarResponse);
@@ -311,13 +303,6 @@ public class {{classname}} {
         );
         {{/vendorExtensions.x-java-text-plain-string}}
       } finally {
-        {{^returnType}}
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
-        {{/returnType}}
       }
     } catch (IOException e) {
       throw new ApiException(e);

--- a/basyx.aasrepository/basyx.aasrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/client/internal/AssetAdministrationShellRepositoryApi.java
+++ b/basyx.aasrepository/basyx.aasrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/client/internal/AssetAdministrationShellRepositoryApi.java
@@ -25,7 +25,6 @@
 package org.eclipse.digitaltwin.basyx.aasrepository.client.internal;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -63,9 +62,6 @@ public class AssetAdministrationShellRepositoryApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-
-  private final Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
   private TokenManager tokenManager;
   
   public AssetAdministrationShellRepositoryApi() {
@@ -102,14 +98,11 @@ public class AssetAdministrationShellRepositoryApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
-    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
-    memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
   }
 
-  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    String message = formatExceptionMessage(operationId, response.statusCode(), body);
-    return new ApiException(response.statusCode(), message, response.headers(), body);
+	protected ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+		String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+		return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
@@ -154,12 +147,10 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<Void> deleteAssetAdministrationShellByIdWithHttpInfoNoUrlEncoding(String aasIdentifier) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = deleteAssetAdministrationShellByIdRequestBuilder(aasIdentifier);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+          HttpResponse.BodyHandlers.ofString());
+      
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("deleteAssetAdministrationShellById", localVarResponse);
@@ -170,11 +161,6 @@ public class AssetAdministrationShellRepositoryApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);
@@ -251,12 +237,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<Void> deleteSubmodelReferenceByIdAasRepositoryWithHttpInfoNoUrlEncoding(String aasIdentifier, String submodelIdentifier) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = deleteSubmodelReferenceByIdAasRepositoryRequestBuilder(aasIdentifier, submodelIdentifier);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("deleteSubmodelReferenceByIdAasRepository", localVarResponse);
@@ -267,11 +250,6 @@ public class AssetAdministrationShellRepositoryApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);
@@ -344,10 +322,8 @@ public class AssetAdministrationShellRepositoryApi {
 	private ApiResponse<Base64UrlEncodedCursorResult<List<AssetAdministrationShell>>> getAllAssetAdministrationShellsApiResponse(List<String> assetIds, String idShort, Integer limit, String cursor) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getAllAssetAdministrationShellsRequestBuilder(assetIds, idShort, limit, cursor);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getAllAssetAdministrationShells", localVarResponse);
@@ -446,12 +422,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<AssetAdministrationShell> getAssetAdministrationShellByIdWithHttpInfoNoUrlEncoding(String aasIdentifier) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getAssetAdministrationShellByIdRequestBuilder(aasIdentifier);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getAssetAdministrationShellById", localVarResponse);
@@ -535,12 +508,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<Reference> getAssetAdministrationShellByIdReferenceAasRepositoryWithHttpInfoNoUrlEncoding(String aasIdentifier) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getAssetAdministrationShellByIdReferenceAasRepositoryRequestBuilder(aasIdentifier);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getAssetAdministrationShellByIdReferenceAasRepository", localVarResponse);
@@ -624,12 +594,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<AssetInformation> getAssetInformationAasRepositoryWithHttpInfoNoUrlEncoding(String aasIdentifier) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getAssetInformationAasRepositoryRequestBuilder(aasIdentifier);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getAssetInformationAasRepository", localVarResponse);
@@ -713,12 +680,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<AssetAdministrationShell> postAssetAdministrationShellWithHttpInfoNoUrlEncoding(AssetAdministrationShell assetAdministrationShell) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = postAssetAdministrationShellRequestBuilder(assetAdministrationShell);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("postAssetAdministrationShell", localVarResponse);
@@ -810,12 +774,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<Reference> postSubmodelReferenceAasRepositoryWithHttpInfoNoUrlEncoding(String aasIdentifier, Reference reference) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = postSubmodelReferenceAasRepositoryRequestBuilder(aasIdentifier, reference);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("postSubmodelReferenceAasRepository", localVarResponse);
@@ -911,12 +872,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<Void> putAssetAdministrationShellByIdWithHttpInfoNoUrlEncoding(String aasIdentifier, AssetAdministrationShell assetAdministrationShell) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = putAssetAdministrationShellByIdRequestBuilder(aasIdentifier, assetAdministrationShell);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("putAssetAdministrationShellById", localVarResponse);
@@ -927,11 +885,6 @@ public class AssetAdministrationShellRepositoryApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);
@@ -1016,12 +969,9 @@ public class AssetAdministrationShellRepositoryApi {
   public ApiResponse<Void> putAssetInformationAasRepositoryWithHttpInfoNoUrlEncoding(String aasIdentifier, AssetInformation assetInformation) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = putAssetInformationAasRepositoryRequestBuilder(aasIdentifier, assetInformation);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("putAssetInformationAasRepository", localVarResponse);
@@ -1032,11 +982,6 @@ public class AssetAdministrationShellRepositoryApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);

--- a/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/internal/AssetAdministrationShellServiceApi.java
+++ b/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/internal/AssetAdministrationShellServiceApi.java
@@ -74,7 +74,6 @@ public class AssetAdministrationShellServiceApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
   private TokenManager tokenManager;
 
   public AssetAdministrationShellServiceApi() {
@@ -111,14 +110,19 @@ public class AssetAdministrationShellServiceApi {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
-    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    String message = formatExceptionMessage(operationId, response.statusCode(), body);
-    return new ApiException(response.statusCode(), message, response.headers(), body);
+	protected ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+		String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+		return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
+
+	protected ApiException getApiExceptionInputStream(String operationId, HttpResponse<InputStream> response)
+			throws IOException {
+		String body = response.body() == null ? null : new String(response.body().readAllBytes());
+		String message = formatExceptionMessage(operationId, response.statusCode(), body);
+		return new ApiException(response.statusCode(), message, response.headers(), body);
+	}
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
     if (body == null || body.isEmpty()) {
@@ -170,21 +174,14 @@ public class AssetAdministrationShellServiceApi {
 	public ApiResponse<Void> deleteSubmodelReferenceByIdWithHttpInfoNoUrlEncoding(String submodelIdentifier) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = deleteSubmodelReferenceByIdRequestBuilder(submodelIdentifier);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("deleteSubmodelReferenceById", localVarResponse);
 				}
 				return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 			} finally {
-				// Drain the InputStream
-				while (localVarResponse.body().read() != -1) {
-					// Ignore
-				}
-				localVarResponse.body().close();
 			}
 		} catch (IOException e) {
 			throw new ApiException(e);
@@ -252,12 +249,10 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<Void> deleteThumbnailWithHttpInfoNoUrlEncoding() throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = deleteThumbnailRequestBuilder();
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
+
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("deleteThumbnail", localVarResponse);
@@ -268,11 +263,6 @@ public class AssetAdministrationShellServiceApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);
@@ -326,10 +316,8 @@ public class AssetAdministrationShellServiceApi {
 	private ApiResponse<Base64UrlEncodedCursorResult<List<Reference>>> getAllSubmodelReferencesApiResponse(Integer limit, String cursor) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getAllSubmodelReferencesRequestBuilder(limit, cursor);
     try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-      }
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+				HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getAllSubmodelReferences", localVarResponse);
@@ -417,12 +405,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<AssetAdministrationShell> getAssetAdministrationShellWithHttpInfoNoUrlEncoding() throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getAssetAdministrationShellRequestBuilder();
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getAssetAdministrationShell", localVarResponse);
@@ -495,12 +480,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<Reference> getAssetAdministrationShellReferenceWithHttpInfoNoUrlEncoding() throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getAssetAdministrationShellReferenceRequestBuilder();
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getAssetAdministrationShellReference", localVarResponse);
@@ -575,12 +557,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<AssetInformation> getAssetInformationWithHttpInfoNoUrlEncoding() throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getAssetInformationRequestBuilder();
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getAssetInformation", localVarResponse);
@@ -655,12 +634,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<ServiceDescription> getDescriptionWithHttpInfoNoUrlEncoding() throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = getDescriptionRequestBuilder();
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("getDescription", localVarResponse);
@@ -733,12 +709,10 @@ public class AssetAdministrationShellServiceApi {
 	public ApiResponse<File> getThumbnailWithHttpInfoNoUrlEncoding() throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getThumbnailRequestBuilder();
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofInputStream());
 			if (localVarResponse.statusCode() / 100 != 2) {
-				throw getApiException("getThumbnail", localVarResponse);
+				throw getApiExceptionInputStream("getThumbnail", localVarResponse);
 			}
 			if (localVarResponse.body() == null) {
 				return new ApiResponse<File>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
@@ -816,12 +790,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<Reference> postSubmodelReferenceWithHttpInfoNoUrlEncoding(Reference reference) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = postSubmodelReferenceRequestBuilder(reference);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("postSubmodelReference", localVarResponse);
@@ -907,12 +878,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<Void> putAssetAdministrationShellWithHttpInfoNoUrlEncoding(AssetAdministrationShell assetAdministrationShell) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = putAssetAdministrationShellRequestBuilder(assetAdministrationShell);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("putAssetAdministrationShell", localVarResponse);
@@ -923,11 +891,6 @@ public class AssetAdministrationShellServiceApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);
@@ -1003,12 +966,9 @@ public class AssetAdministrationShellServiceApi {
   public ApiResponse<Void> putAssetInformationWithHttpInfoNoUrlEncoding(AssetInformation assetInformation) throws ApiException {
     HttpRequest.Builder localVarRequestBuilder = putAssetInformationRequestBuilder(assetInformation);
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+		HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+				HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("putAssetInformation", localVarResponse);
@@ -1019,11 +979,6 @@ public class AssetAdministrationShellServiceApi {
           null
         );
       } finally {
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
       }
     } catch (IOException e) {
       throw new ApiException(e);
@@ -1087,17 +1042,14 @@ public class AssetAdministrationShellServiceApi {
 	private ApiResponse<Void> putThumbnailWithHttpInfoNoUrlEncoding(String fileName, ContentType contentType, InputStream inputStream) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = putThumbnailRequestBuilder(fileName, contentType, inputStream);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("putThumbnail", localVarResponse);
 				}
 				return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 			} finally {
-				localVarResponse.body().close();
 			}
 		} catch (IOException e) {
 			throw new ApiException(e);

--- a/basyx.submodelregistry/basyx.submodelregistry-client-native/pom.xml
+++ b/basyx.submodelregistry/basyx.submodelregistry-client-native/pom.xml
@@ -90,6 +90,7 @@
 								<dateLibrary>java8</dateLibrary>
 								<sourceFolder>java</sourceFolder>
 								<useJakartaEe>true</useJakartaEe>
+								<returnResponse>true</returnResponse>
 							</configOptions>
 						</configuration>
 					</execution>

--- a/basyx.submodelregistry/basyx.submodelregistry-client-native/pom.xml
+++ b/basyx.submodelregistry/basyx.submodelregistry-client-native/pom.xml
@@ -90,7 +90,6 @@
 								<dateLibrary>java8</dateLibrary>
 								<sourceFolder>java</sourceFolder>
 								<useJakartaEe>true</useJakartaEe>
-								<returnResponse>true</returnResponse>
 							</configOptions>
 						</configuration>
 					</execution>

--- a/basyx.submodelregistry/basyx.submodelregistry-client-native/templates/libraries/native/api.mustache
+++ b/basyx.submodelregistry/basyx.submodelregistry-client-native/templates/libraries/native/api.mustache
@@ -59,8 +59,6 @@ public class {{classname}} {
   private final String memberVarBaseUri;
   private final {{#fullJavaUtil}}java.util.function.{{/fullJavaUtil}}Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-  private final {{#fullJavaUtil}}java.util.function.{{/fullJavaUtil}}Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  private final {{#fullJavaUtil}}java.util.function.{{/fullJavaUtil}}Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
   private TokenManager tokenManager;
   
   public {{classname}}() {
@@ -101,8 +99,6 @@ public class {{classname}} {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
-    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
-    memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
   }
   {{#asyncNative}}
 
@@ -113,10 +109,9 @@ public class {{classname}} {
   {{/asyncNative}}
   {{^asyncNative}}
 
-  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    String message = formatExceptionMessage(operationId, response.statusCode(), body);
-    return new ApiException(response.statusCode(), message, response.headers(), body);
+  protected ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
   {{/asyncNative}}
 
@@ -273,12 +268,9 @@ public class {{classname}} {
     {{^asyncNative}}
     HttpRequest.Builder localVarRequestBuilder = {{operationId}}RequestBuilder({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
     try {
-      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+      HttpResponse<String> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
-          HttpResponse.BodyHandlers.ofInputStream());
-      if (memberVarResponseInterceptor != null) {
-        memberVarResponseInterceptor.accept(localVarResponse);
-      }
+          HttpResponse.BodyHandlers.ofString());
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
           throw getApiException("{{operationId}}", localVarResponse);
@@ -311,13 +303,6 @@ public class {{classname}} {
         );
         {{/vendorExtensions.x-java-text-plain-string}}
       } finally {
-        {{^returnType}}
-        // Drain the InputStream
-        while (localVarResponse.body().read() != -1) {
-            // Ignore
-        }
-        localVarResponse.body().close();
-        {{/returnType}}
       }
     } catch (IOException e) {
       throw new ApiException(e);

--- a/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/internal/SubmodelRepositoryApi.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/internal/SubmodelRepositoryApi.java
@@ -25,14 +25,12 @@
 package org.eclipse.digitaltwin.basyx.submodelrepository.client.internal;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
@@ -62,8 +60,6 @@ public class SubmodelRepositoryApi {
 	private final String memberVarBaseUri;
 	private final Consumer<HttpRequest.Builder> memberVarInterceptor;
 	private final Duration memberVarReadTimeout;
-	private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-	private final Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
 	private TokenManager tokenManager;
 	
 	public SubmodelRepositoryApi() {
@@ -99,14 +95,11 @@ public class SubmodelRepositoryApi {
 		memberVarBaseUri = apiClient.getBaseUri();
 		memberVarInterceptor = apiClient.getRequestInterceptor();
 		memberVarReadTimeout = apiClient.getReadTimeout();
-		memberVarResponseInterceptor = apiClient.getResponseInterceptor();
-		memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
 	}
 
-	protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-		String body = response.body() == null ? null : new String(response.body().readAllBytes());
-		String message = formatExceptionMessage(operationId, response.statusCode(), body);
-		return new ApiException(response.statusCode(), message, response.headers(), body);
+	protected ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+		String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+		return new ApiException(response.statusCode(), message, response.headers(), response.body());
 	}
 
 	private String formatExceptionMessage(String operationId, int statusCode, String body) {
@@ -174,10 +167,8 @@ public class SubmodelRepositoryApi {
 	public ApiResponse<Submodel> getSubmodelByIdWithHttpInfoNoUrlEncoding(String submodelIdentifier, String level, String extent) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getSubmodelByIdRequestBuilder(submodelIdentifier, level, extent);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getSubmodelById", localVarResponse);
@@ -290,10 +281,8 @@ public class SubmodelRepositoryApi {
 	public ApiResponse<Submodel> getSubmodelByIdMetadataWithHttpInfoNoUrlEncoding(String submodelIdentifier, String level) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getSubmodelByIdMetadataRequestBuilder(submodelIdentifier, level);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getSubmodelByIdMetadata", localVarResponse);
@@ -301,8 +290,9 @@ public class SubmodelRepositoryApi {
 				Submodel deserializedSubmodel = localVarResponse.body() == null ? null : memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<Submodel>() {
 				});
 
-				if (deserializedSubmodel != null && deserializedSubmodel.getSubmodelElements() != null && deserializedSubmodel.getSubmodelElements().isEmpty())
+				if (deserializedSubmodel != null && deserializedSubmodel.getSubmodelElements() != null && deserializedSubmodel.getSubmodelElements().isEmpty()) {
 					deserializedSubmodel.setSubmodelElements(null);
+				}
 
 				return new ApiResponse<>(localVarResponse.statusCode(), localVarResponse.headers().map(), deserializedSubmodel);
 			} finally {
@@ -397,10 +387,8 @@ public class SubmodelRepositoryApi {
 	public ApiResponse<Submodel> postSubmodelWithHttpInfoNoUrlEncoding(Submodel submodel) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = postSubmodelRequestBuilder(submodel);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("postSubmodel", localVarResponse);
@@ -497,21 +485,14 @@ public class SubmodelRepositoryApi {
 	public ApiResponse<Void> putSubmodelByIdWithHttpInfoNoUrlEncoding(String submodelIdentifier, Submodel submodel) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = putSubmodelByIdRequestBuilder(submodelIdentifier, submodel);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("putSubmodelById", localVarResponse);
 				}
 				return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 			} finally {
-				// Drain the InputStream
-				while (localVarResponse.body().read() != -1) {
-					// Ignore
-				}
-				localVarResponse.body().close();
 			}
 		} catch (IOException e) {
 			throw new ApiException(e);
@@ -597,21 +578,14 @@ public class SubmodelRepositoryApi {
 	public ApiResponse<Void> deleteSubmodelByIdWithHttpInfoNoUrlEncoding(String submodelIdentifier) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = deleteSubmodelByIdRequestBuilder(submodelIdentifier);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("deleteSubmodelById", localVarResponse);
 				}
 				return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 			} finally {
-				// Drain the InputStream
-				while (localVarResponse.body().read() != -1) {
-					// Ignore
-				}
-				localVarResponse.body().close();
 			}
 		} catch (IOException e) {
 			throw new ApiException(e);
@@ -680,10 +654,8 @@ public class SubmodelRepositoryApi {
 	private ApiResponse<Base64UrlEncodedCursorResult<List<Submodel>>> getAllSubmodelsApiResponse(String semanticId, String idShort, Integer limit, String cursor, String level, String extent) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getAllSubmodelsRequestBuilder(semanticId, idShort, limit, cursor, level, extent);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getAllSubmodels", localVarResponse);

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/internal/SubmodelServiceApi.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/internal/SubmodelServiceApi.java
@@ -74,8 +74,6 @@ public class SubmodelServiceApi {
   private final String memberVarBaseUri;
   private final Consumer<HttpRequest.Builder> memberVarInterceptor;
   private final Duration memberVarReadTimeout;
-  private final Consumer<HttpResponse<InputStream>> memberVarResponseInterceptor;
-  private final Consumer<HttpResponse<String>> memberVarAsyncResponseInterceptor;
 	
   private TokenManager tokenManager;
 
@@ -114,15 +112,19 @@ public SubmodelServiceApi(ApiClient apiClient) {
     memberVarBaseUri = apiClient.getBaseUri();
     memberVarInterceptor = apiClient.getRequestInterceptor();
     memberVarReadTimeout = apiClient.getReadTimeout();
-    memberVarResponseInterceptor = apiClient.getResponseInterceptor();
-	memberVarAsyncResponseInterceptor = apiClient.getAsyncResponseInterceptor();
   }
 
-  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    String message = formatExceptionMessage(operationId, response.statusCode(), body);
-    return new ApiException(response.statusCode(), message, response.headers(), body);
-  }
+	protected ApiException getApiException(String operationId, HttpResponse<String> response) throws IOException {
+		String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+		return new ApiException(response.statusCode(), message, response.headers(), response.body());
+	}
+
+	protected ApiException getApiExceptionInputStream(String operationId, HttpResponse<InputStream> response)
+			throws IOException {
+		String body = response.body() == null ? null : new String(response.body().readAllBytes());
+		String message = formatExceptionMessage(operationId, response.statusCode(), body);
+		return new ApiException(response.statusCode(), message, response.headers(), body);
+	}
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
     if (body == null || body.isEmpty()) {
@@ -184,10 +186,9 @@ public SubmodelServiceApi(ApiClient apiClient) {
 	public ApiResponse<Submodel> getSubmodelWithHttpInfoNoUrlEncoding(String level, String extent) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getSubmodelRequestBuilder(level, extent);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
+
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getSubmodel", localVarResponse);
@@ -304,10 +305,9 @@ public SubmodelServiceApi(ApiClient apiClient) {
 	public ApiResponse<SubmodelElement> getSubmodelElementByPathWithHttpInfoNoUrlEncoding(String idShortPath, String level, String extent) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getSubmodelElementByPathRequestBuilder(idShortPath, level, extent);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
+
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getSubmodelElementByPath", localVarResponse);
@@ -431,10 +431,9 @@ public SubmodelServiceApi(ApiClient apiClient) {
 	public ApiResponse<SubmodelElementValue> getSubmodelElementByPathValueOnlyWithHttpInfoNoUrlEncoding(String idShortPath, String level, String extent) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = getSubmodelElementByPathValueOnlyRequestBuilder(idShortPath, level, extent);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
+
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("getSubmodelElementByPathValueOnly", localVarResponse);
@@ -568,21 +567,15 @@ public SubmodelServiceApi(ApiClient apiClient) {
 	public ApiResponse<Void> patchSubmodelElementByPathValueOnlyWithHttpInfoNoUrlEncoding(String idShortPath, SubmodelElementValue getSubmodelElementsValueResult, Integer limit, String cursor, String level) throws ApiException {
 		HttpRequest.Builder localVarRequestBuilder = patchSubmodelElementByPathValueOnlyRequestBuilder(idShortPath, getSubmodelElementsValueResult, limit, cursor, level);
 		try {
-			HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-			if (memberVarResponseInterceptor != null) {
-				memberVarResponseInterceptor.accept(localVarResponse);
-			}
+			HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+					HttpResponse.BodyHandlers.ofString());
+
 			try {
 				if (localVarResponse.statusCode() / 100 != 2) {
 					throw getApiException("patchSubmodelElementByPathValueOnly", localVarResponse);
 				}
 				return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 			} finally {
-				// Drain the InputStream
-				while (localVarResponse.body().read() != -1) {
-					// Ignore
-				}
-				localVarResponse.body().close();
 			}
 		} catch (IOException e) {
 			throw new ApiException(e);
@@ -683,12 +676,9 @@ public SubmodelServiceApi(ApiClient apiClient) {
 	  public ApiResponse<SubmodelElement> postSubmodelElementWithHttpInfoNoUrlEncoding(SubmodelElement submodelElement) throws ApiException {
 	    HttpRequest.Builder localVarRequestBuilder = postSubmodelElementRequestBuilder(submodelElement);
 	    try {
-	      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+	      HttpResponse<String> localVarResponse = memberVarHttpClient.send(
 	          localVarRequestBuilder.build(),
-	          HttpResponse.BodyHandlers.ofInputStream());
-	      if (memberVarResponseInterceptor != null) {
-	        memberVarResponseInterceptor.accept(localVarResponse);
-	      }
+					HttpResponse.BodyHandlers.ofString());
 	      try {
 	        if (localVarResponse.statusCode()/ 100 != 2) {
 	          throw getApiException("postSubmodelElement", localVarResponse);
@@ -791,10 +781,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		public ApiResponse<SubmodelElement> postSubmodelElementByPathWithHttpInfoNoUrlEncoding(String idShortPath, SubmodelElement submodelElement) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = postSubmodelElementByPathRequestBuilder(idShortPath, submodelElement);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("postSubmodelElementByPath", localVarResponse);
@@ -905,21 +893,14 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		public ApiResponse<Void> putSubmodelElementByPathWithHttpInfoNoUrlEncoding(String idShortPath, SubmodelElement submodelElement, String level) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = putSubmodelElementByPathRequestBuilder(idShortPath, submodelElement, level);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("putSubmodelElementByPath", localVarResponse);
 					}
 					return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 				} finally {
-					// Drain the InputStream
-					while (localVarResponse.body().read() != -1) {
-						// Ignore
-					}
-					localVarResponse.body().close();
 				}
 			} catch (IOException e) {
 				throw new ApiException(e);
@@ -1022,21 +1003,14 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		public ApiResponse<Void> deleteSubmodelElementByPathWithHttpInfoNoUrlEncoding(String idShortPath) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = deleteSubmodelElementByPathRequestBuilder(idShortPath);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("deleteSubmodelElementByPath", localVarResponse);
 					}
 					return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 				} finally {
-					// Drain the InputStream
-					while (localVarResponse.body().read() != -1) {
-						// Ignore
-					}
-					localVarResponse.body().close();
 				}
 			} catch (IOException e) {
 				throw new ApiException(e);
@@ -1101,10 +1075,9 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		private ApiResponse<Base64UrlEncodedCursorResult<List<SubmodelElement>>> getAllSubmodelElementsApiResponse(Integer limit, String cursor, String level, String extent) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = getAllSubmodelElementsRequestBuilder(limit, cursor, level, extent);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
+
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("getAllSubmodelElements", localVarResponse);
@@ -1186,21 +1159,14 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		private ApiResponse<Void> putFileByPathApiResponse(String idShortPath, String fileName, InputStream inputStream) throws ApiException {
 			try {
 				HttpRequest.Builder localVarRequestBuilder = putFileByPathRequestBuilder(idShortPath, fileName, inputStream);
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("putFileByPath", localVarResponse);
 					}
 					return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 				} finally {
-					// Drain the InputStream
-					while (localVarResponse.body().read() != -1) {
-						// Ignore
-					}
-					localVarResponse.body().close();
 				}
 			} catch (IOException e) {
 				throw new ApiException(e);
@@ -1211,10 +1177,12 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		}
 
 		private HttpRequest.Builder putFileByPathRequestBuilder(String idShortPath, String fileName, InputStream inputStream) throws ApiException, IOException {
-			if (idShortPath == null)
+			if (idShortPath == null) {
 				throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling putFileByPath");
-			if (inputStream == null)
+			}
+			if (inputStream == null) {
 				throw new ApiException(400, "Missing the required parameter 'inputStream' when calling putFileByPath");
+			}
 
 			HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
@@ -1297,21 +1265,14 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		public ApiResponse<Void> deleteFileByPathWithHttpInfoNoUrlEncoding(String idShortPath) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = deleteFileByPathRequestBuilder(idShortPath);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("deleteFileByPath", localVarResponse);
 					}
 					return new ApiResponse<Void>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
 				} finally {
-					// Drain the InputStream
-					while (localVarResponse.body().read() != -1) {
-						// Ignore
-					}
-					localVarResponse.body().close();
 				}
 			} catch (IOException e) {
 				throw new ApiException(e);
@@ -1365,12 +1326,10 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		private ApiResponse<File> getFileByPathApiResponse(String idShortPath) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = getFileByPathRequestBuilder(idShortPath);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofInputStream());
 				if (localVarResponse.statusCode() / 100 != 2) {
-					throw getApiException("getFileByPath", localVarResponse);
+					throw getApiExceptionInputStream("getFileByPath", localVarResponse);
 				}
 				if (localVarResponse.body() == null) {
 					return new ApiResponse<File>(localVarResponse.statusCode(), localVarResponse.headers().map(), null);
@@ -1463,10 +1422,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		public ApiResponse<OperationResult> invokeOperationWithHttpInfoNoUrlEncoding(String idShortPath, OperationRequest operationRequest) throws ApiException {
 			HttpRequest.Builder localVarRequestBuilder = invokeOperationRequestBuilder(idShortPath, operationRequest);
 			try {
-				HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
-				if (memberVarResponseInterceptor != null) {
-					memberVarResponseInterceptor.accept(localVarResponse);
-				}
+				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
+						HttpResponse.BodyHandlers.ofString());
 				try {
 					if (localVarResponse.statusCode() / 100 != 2) {
 						throw getApiException("invokeOperation", localVarResponse);


### PR DESCRIPTION
## Description of Changes

Usage of _ofInputStream_ led to usage of lots of ports due to inputstreams closing not being fast enough. By using _ofString_ instead where applicable, this issue is fixed.

## BaSyx Configuration for Testing
For testing, use the basyx minimal example with the following test project:
[basyx-socket-example.zip](https://github.com/user-attachments/files/20755383/basyx-socket-example.zip)

Use _netstat -np tcp | find ":8083"_ for checking. There should be only one connection per thread per component.
