### PR TITLE
Adds ContentType to setFileValue

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -198,7 +198,7 @@ public class DefaultAASEnvironment implements AasEnvironment {
 			return;
 		}
 
-		submodelRepository.setFileValue(submodelId, fileSMEIdShortPath, getFileName(inMemoryFile.getPath()), new ByteArrayInputStream(inMemoryFile.getFileContent()));
+		submodelRepository.setFileValue(submodelId, fileSMEIdShortPath, getFileName(inMemoryFile.getPath()), "application/octet-stream", new ByteArrayInputStream(inMemoryFile.getFileContent()));
 	}
 
 	private String getFileName(String path) {

--- a/basyx.submodelrepository/basyx.submodelrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/backend/CrudSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/backend/CrudSubmodelRepository.java
@@ -204,8 +204,8 @@ public class CrudSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		getService(submodelId).setFileValue(idShortPath, fileName, inputStream);
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+		getService(submodelId).setFileValue(idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/ConnectedSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/ConnectedSubmodelRepository.java
@@ -235,8 +235,8 @@ public class ConnectedSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		getConnectedSubmodelService(submodelId).setFileValue(idShortPath, fileName, inputStream);
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+		getConnectedSubmodelService(submodelId).setFileValue(idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/SubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/SubmodelRepository.java
@@ -252,11 +252,17 @@ public interface SubmodelRepository {
 	 *            the Submodel id
 	 * @param idShortPath
 	 *            the IdShort path of the file element
+	 * @param fileName
+	 *            the file name
+	 * @param contentType
+	 *            the content type of the file
+	 * @param inputStream
+	 *            the inputStream of the file to be uploaded
 	 * 
 	 * @throws ElementDoesNotExistException
 	 * @throws ElementNotAFileException
 	 */
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException;
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException;
 
 	/**
 	 * Deletes the file of a file submodelelement

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositoryPersistencyTestSuite.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositoryPersistencyTestSuite.java
@@ -66,7 +66,7 @@ public abstract class SubmodelRepositoryPersistencyTestSuite {
 		Submodel submodel = DummySubmodelFactory.createSubmodelWithFileElement();
 		getSubmodelRepository().createSubmodel(submodel);
 
-		getSubmodelRepository().setFileValue(DummySubmodelFactory.SUBMODEL_FOR_FILE_TEST, SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "dummyFile.jpeg", createDummyImageIS_A());
+		getSubmodelRepository().setFileValue(DummySubmodelFactory.SUBMODEL_FOR_FILE_TEST, SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "dummyFile.jpeg", "image/jpeg", createDummyImageIS_A());
 
 		restartComponent();
 

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositorySubmodelServiceWrapper.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositorySubmodelServiceWrapper.java
@@ -125,8 +125,8 @@ public class SubmodelRepositorySubmodelServiceWrapper implements SubmodelService
 	}
 
 	@Override
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		repoApi.setFileValue(submodelId, idShortPath, fileName, inputStream);
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+		repoApi.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/authorization/AuthorizedSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/authorization/AuthorizedSubmodelRepository.java
@@ -278,12 +278,12 @@ public class AuthorizedSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new SubmodelTargetInformation(getIdAsList(submodelId), getIdAsList(idShortPath)));
 
 		throwExceptionIfInsufficientPermission(isAuthorized);
 
-		decorated.setFileValue(submodelId, idShortPath, fileName, inputStream);
+		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/kafka/KafkaSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/kafka/KafkaSubmodelRepository.java
@@ -180,8 +180,8 @@ public class KafkaSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) {
-		decorated.setFileValue(submodelId, idShortPath, fileName, inputStream);
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) {
+		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/MqttSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/MqttSubmodelRepository.java
@@ -191,8 +191,8 @@ public class MqttSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream){
-		decorated.setFileValue(submodelId, idShortPath, fileName, inputStream);
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream){
+		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 		SubmodelElement submodelElement = decorated.getSubmodelElement(submodelId, idShortPath);
 		fileValueUpdated(submodelElement, getName(), submodelId, idShortPath);
 	}

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/TestMqttSubmodelObserver.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/TestMqttSubmodelObserver.java
@@ -221,7 +221,7 @@ public class TestMqttSubmodelObserver {
 	
 		File submodelElement = (File) submodel.getSubmodelElements().get(0); 
 		
-		submodelRepository.setFileValue(submodel.getId(), submodelElement.getIdShort(), FILE_SUBMODEL_ELEMENT_NAME, getInputStreamOfDummyFile(FILE_SUBMODEL_ELEMENT_CONTENT));
+		submodelRepository.setFileValue(submodel.getId(), submodelElement.getIdShort(), FILE_SUBMODEL_ELEMENT_NAME, "application/octet-stream", getInputStreamOfDummyFile(FILE_SUBMODEL_ELEMENT_CONTENT));
 		
 		assertEquals(topicFactory.createUpdateFileValueTopic(submodelRepository.getName(), submodel.getId(), submodelElement.getIdShort()), listener.lastTopic);
 		assertEquals(submodelElement, deserializeSubmodelElementPayload(listener.lastPayload));

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-operation-delegation/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/operation/delegation/OperationDelegationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-operation-delegation/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/operation/delegation/OperationDelegationSubmodelRepository.java
@@ -159,8 +159,8 @@ public class OperationDelegationSubmodelRepository implements SubmodelRepository
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		decorated.setFileValue(submodelId, idShortPath, fileName, inputStream);
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 		
 	}
 

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
@@ -174,8 +174,8 @@ public class RegistryIntegrationSubmodelRepository implements SubmodelRepository
 	}
 
 	@Override
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		decorated.setFileValue(submodelId, idShortPath, fileName, inputStream);
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
@@ -243,7 +243,7 @@ public class SubmodelRepositoryApiHTTPController implements SubmodelRepositoryHT
 		InputStream fileInputstream = null;
 		try {
 			fileInputstream = file.getInputStream();
-			repository.setFileValue(submodelIdentifier.getIdentifier(), idShortPath, fileName, fileInputstream);
+			repository.setFileValue(submodelIdentifier.getIdentifier(), idShortPath, fileName, file.getContentType(), fileInputstream);
 			closeInputStream(fileInputstream);
 			return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 		} catch (ElementDoesNotExistException e) {

--- a/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/CrudSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/CrudSubmodelService.java
@@ -208,8 +208,8 @@ public class CrudSubmodelService implements SubmodelService {
     }
 
     @Override
-    public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-        submodelFileOperations.setFileValue(submodelId, idShortPath, fileName, inputStream);
+    public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+        submodelFileOperations.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
     }
 
     @Override

--- a/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/SubmodelFileOperations.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/SubmodelFileOperations.java
@@ -68,7 +68,7 @@ public class SubmodelFileOperations  {
 		return createFile(filePath, fileContent);
 	}
 
-	public void setFileValue(String submodelId, String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
         SubmodelElement submodelElement = submodelOperations.getSubmodelElement(submodelId, idShortPath);
 
         throwIfSmElementIsNotAFile(submodelElement);
@@ -80,14 +80,14 @@ public class SubmodelFileOperations  {
 
         String uniqueFileName = createUniqueFileName(submodelId, idShortPath, fileName);
 
-        FileMetadata fileMetadata = new FileMetadata(uniqueFileName, fileSmElement.getContentType(), inputStream);
+        FileMetadata fileMetadata = new FileMetadata(uniqueFileName, contentType, inputStream);
 
         if (fileRepository.exists(fileMetadata.getFileName()))
             fileRepository.delete(fileMetadata.getFileName());
 
         String filePath = fileRepository.save(fileMetadata);
 
-        FileBlobValue fileValue = new FileBlobValue(fileSmElement.getContentType(), filePath);
+        FileBlobValue fileValue = new FileBlobValue(contentType, filePath);
 
         submodelOperations.setSubmodelElementValue(submodelId, idShortPath, fileValue);
 	}

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/ConnectedSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/ConnectedSubmodelService.java
@@ -180,9 +180,9 @@ public class ConnectedSubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		try {
-			serviceApi.putFileByPath(idShortPath, fileName, inputStream);
+			serviceApi.putFileByPath(idShortPath, fileName, contentType, inputStream);
 		} catch (ApiException e) {
 			throw mapExceptionFileAccess(idShortPath, e);
 		}

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/internal/SubmodelServiceApi.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/internal/SubmodelServiceApi.java
@@ -1147,18 +1147,20 @@ public SubmodelServiceApi(ApiClient apiClient) {
 		 *            IdShort path to the submodel element (dot-separated) (required)
 		 * @param fileName
 		 *            (optional)
+		 * @param contentType
+		 *            content type of the file (optional)
 		 * @param inputStream
 		 *            (optional)
 		 * @throws ApiException
 		 *             if fails to make API call
 		 */
-		public void putFileByPath(String idShortPath, String fileName, InputStream inputStream) throws ApiException {
-			putFileByPathApiResponse(idShortPath, fileName, inputStream);
+		public void putFileByPath(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ApiException {
+			putFileByPathApiResponse(idShortPath, fileName, contentType, inputStream);
 		}
 
-		private ApiResponse<Void> putFileByPathApiResponse(String idShortPath, String fileName, InputStream inputStream) throws ApiException {
+		private ApiResponse<Void> putFileByPathApiResponse(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ApiException {
 			try {
-				HttpRequest.Builder localVarRequestBuilder = putFileByPathRequestBuilder(idShortPath, fileName, inputStream);
+				HttpRequest.Builder localVarRequestBuilder = putFileByPathRequestBuilder(idShortPath, fileName, contentType, inputStream);
 				HttpResponse<String> localVarResponse = memberVarHttpClient.send(localVarRequestBuilder.build(),
 						HttpResponse.BodyHandlers.ofString());
 				try {
@@ -1176,7 +1178,7 @@ public SubmodelServiceApi(ApiClient apiClient) {
 			}
 		}
 
-		private HttpRequest.Builder putFileByPathRequestBuilder(String idShortPath, String fileName, InputStream inputStream) throws ApiException, IOException {
+		private HttpRequest.Builder putFileByPathRequestBuilder(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ApiException, IOException {
 			if (idShortPath == null) {
 				throw new ApiException(400, "Missing the required parameter 'idShortPath' when calling putFileByPath");
 			}
@@ -1194,7 +1196,8 @@ public SubmodelServiceApi(ApiClient apiClient) {
 
 			var multiPartBuilder = MultipartEntityBuilder.create();
 			multiPartBuilder.addTextBody("fileName", fileName);
-			multiPartBuilder.addBinaryBody("file", inputStream, ContentType.DEFAULT_BINARY, fileName);
+			ContentType fileContentType = contentType != null ? ContentType.parse(contentType) : ContentType.DEFAULT_BINARY;
+			multiPartBuilder.addBinaryBody("file", inputStream, fileContentType, fileName);
 
 			var entity = multiPartBuilder.build();
 			HttpRequest.BodyPublisher formDataPublisher;

--- a/basyx.submodelservice/basyx.submodelservice-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelService.java
@@ -165,13 +165,15 @@ public interface SubmodelService {
 	 *            the IdShort path of the file element
 	 * @param fileName
 	 *            the file name
+	 * @param contentType
+	 *            the content type of the file
 	 * @param inputStream
 	 *            the inputStream of the file to be uploaded
 	 * 
 	 * @throws ElementDoesNotExistException
 	 * @throws ElementNotAFileException
 	 */
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException;
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException;
 
 	/**
 	 * Deletes the file of a file submodelelement

--- a/basyx.submodelservice/basyx.submodelservice-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelServiceSuite.java
+++ b/basyx.submodelservice/basyx.submodelservice-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelServiceSuite.java
@@ -429,7 +429,7 @@ public abstract class SubmodelServiceSuite {
 
 		String idShortPathPropertyInSmeCol = SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_SUBMODEL_ELEMENT_COLLECTION_ID_SHORT + "." + SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT;
 
-		submodelService.setFileValue(idShortPathPropertyInSmeCol, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(idShortPathPropertyInSmeCol, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		String fileValue = ((File) submodelService.getSubmodelElement(idShortPathPropertyInSmeCol)).getValue();
 
@@ -452,14 +452,14 @@ public abstract class SubmodelServiceSuite {
 
 		String idShortPathPropertyInSmeCol = SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_SUBMODEL_ELEMENT_COLLECTION_ID_SHORT + "." + SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT;
 
-		submodelService.setFileValue(idShortPathPropertyInSmeCol, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(idShortPathPropertyInSmeCol, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		assertStoredFileContentEquals(submodelService, idShortPathPropertyInSmeCol, DUMMY_JSON_1);
 
 		File newFileSME = SubmodelServiceHelper.createDummyFile(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "text/plain", "someArbitraryPlainText");
 		submodelService.updateSubmodelElement(idShortPathPropertyInSmeCol, newFileSME);
 
-		submodelService.setFileValue(idShortPathPropertyInSmeCol, "jsonFile2.json", getInputStreamOfDummyFile(DUMMY_JSON_2));
+		submodelService.setFileValue(idShortPathPropertyInSmeCol, "jsonFile2.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_2));
 
 		assertStoredFileContentEquals(submodelService, idShortPathPropertyInSmeCol, DUMMY_JSON_2);
 	}
@@ -556,7 +556,7 @@ public abstract class SubmodelServiceSuite {
 		Submodel technicalDataSubmodel = DummySubmodelFactory.createTechnicalDataSubmodel();
 		SubmodelService submodelService = getSubmodelService(technicalDataSubmodel);
 
-		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		SubmodelElement submodelElement = submodelService.getSubmodelElement(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT);
 		String fileValue = ((File) submodelElement).getValue();
@@ -574,7 +574,7 @@ public abstract class SubmodelServiceSuite {
 		SubmodelService submodelService = getSubmodelService(technicalDataSubmodel);
 		String expectedFileExtension = "json";
 
-		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		java.io.File retrievedValue = submodelService.getFileByPath(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT);
 
@@ -587,7 +587,7 @@ public abstract class SubmodelServiceSuite {
 		Submodel technicalDataSubmodel = DummySubmodelFactory.createTechnicalDataSubmodel();
 		SubmodelService submodelService = getSubmodelService(technicalDataSubmodel);
 
-		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		String filePath = ((File)submodelService.getSubmodelElement(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT)).getValue();
 
@@ -612,7 +612,7 @@ public abstract class SubmodelServiceSuite {
 		Submodel technicalDataSubmodel = DummySubmodelFactory.createTechnicalDataSubmodel();
 		SubmodelService submodelService = getSubmodelService(technicalDataSubmodel);
 
-		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		submodelService.deleteFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT);
 
@@ -628,11 +628,11 @@ public abstract class SubmodelServiceSuite {
 		Submodel technicalDataSubmodel = DummySubmodelFactory.createTechnicalDataSubmodel();
 		SubmodelService submodelService = getSubmodelService(technicalDataSubmodel);
 
-		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", getInputStreamOfDummyFile(DUMMY_JSON_1));
+		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile1.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_1));
 
 		assertStoredFileContentEquals(submodelService, SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, DUMMY_JSON_1);
 
-		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile2.json", getInputStreamOfDummyFile(DUMMY_JSON_2));
+		submodelService.setFileValue(SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, "jsonFile2.json", "application/json", getInputStreamOfDummyFile(DUMMY_JSON_2));
 
 		assertStoredFileContentEquals(submodelService, SubmodelServiceHelper.SUBMODEL_TECHNICAL_DATA_FILE_ID_SHORT, DUMMY_JSON_2);
 	}

--- a/basyx.submodelservice/basyx.submodelservice-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/authorization/AuthorizedSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/authorization/AuthorizedSubmodelService.java
@@ -179,10 +179,10 @@ public class AuthorizedSubmodelService implements SubmodelService {
 	}
 	
 	@Override
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new SubmodelTargetInformation(List.of(smId), List.of(idShortPath)));
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		decorated.setFileValue(idShortPath, fileName, inputStream);
+		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);
 	}
 
 	private void throwExceptionIfInsufficientSubmodelAccess() {

--- a/basyx.submodelservice/basyx.submodelservice-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/kafka/KafkaSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/kafka/KafkaSubmodelService.java
@@ -130,9 +130,9 @@ public class KafkaSubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream)
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream)
 			throws ElementDoesNotExistException, ElementNotAFileException {
-		decorated.setFileValue(idShortPath, fileName, inputStream);
+		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/mqtt/MqttSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/mqtt/MqttSubmodelService.java
@@ -140,8 +140,8 @@ public class MqttSubmodelService implements SubmodelService {
 	}
 
 	@Override
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
-		decorated.setFileValue(idShortPath, fileName, inputStream);
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
+		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-feature-operation-dispatching/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/operationdispatching/AbstractSubmodelServiceDecorator.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-operation-dispatching/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/operationdispatching/AbstractSubmodelServiceDecorator.java
@@ -116,9 +116,9 @@ public class AbstractSubmodelServiceDecorator implements SubmodelService {
 	}
 
 	@Override
-	public void setFileValue(String idShortPath, String fileName, InputStream inputStream)
+	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream)
 			throws ElementDoesNotExistException, ElementNotAFileException {
-		decorated.setFileValue(idShortPath, fileName, inputStream);
+		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);
 	}
 
 	@Override

--- a/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
+++ b/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
@@ -268,7 +268,7 @@ public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi 
 		InputStream fileInputstream = null;
 		try {
 			fileInputstream = file.getInputStream();
-			service.setFileValue(idShortPath, fileName, fileInputstream);
+			service.setFileValue(idShortPath, fileName, file.getContentType(), fileInputstream);
 			closeInputStream(fileInputstream);
 			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 		} catch (ElementDoesNotExistException e) {


### PR DESCRIPTION
## Description of Changes

This PR adds the `contentType` parameter to the `setFileValue` method, allowing it to automatically set the content type when using the attachment endpoint. The implementation follows the same pattern as `setThumbnail` in the AAS Service.