### PR TITLE
Fixes problem with hardcoded contentType in AAS Env

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -198,7 +198,8 @@ public class DefaultAASEnvironment implements AasEnvironment {
 			return;
 		}
 
-		submodelRepository.setFileValue(submodelId, fileSMEIdShortPath, getFileName(inMemoryFile.getPath()), "application/octet-stream", new ByteArrayInputStream(inMemoryFile.getFileContent()));
+		String contentType = (fileSME.getContentType() != null && !fileSME.getContentType().trim().isEmpty()) ? fileSME.getContentType() : null;
+		submodelRepository.setFileValue(submodelId, fileSMEIdShortPath, getFileName(inMemoryFile.getPath()), contentType, new ByteArrayInputStream(inMemoryFile.getFileContent()));
 	}
 
 	private String getFileName(String path) {


### PR DESCRIPTION
## Description of Changes

This PR fixes a small bug that got introduced in #791 where the AAS Environment used a hardcoded contentType in `setFileToFileElement`