### PR TITLE
Remove all non null values that are returned

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/RestConfiguration.java
+++ b/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/RestConfiguration.java
@@ -36,14 +36,12 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 @Configuration
-@EnableWebMvc
 public class RestConfiguration extends BaSyxHTTPConfiguration implements WebMvcConfigurer {
 
 	@Bean

--- a/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/WebMvcConfig.java
+++ b/basyx.aasregistry/basyx.aasregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/WebMvcConfig.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (C) 2025 DFKI GmbH (https://www.dfki.de/en/web)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.digitaltwin.basyx.aasregistry.service.configuration;
+
+import java.util.List;
+
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private MappingJackson2HttpMessageConverter converter;
+	
+	public WebMvcConfig(MappingJackson2HttpMessageConverter converter) {
+		this.converter = converter;
+	}
+	
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		converters.add(converter);
+	}
+
+}

--- a/basyx.submodelregistry/basyx.submodelregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/configuration/RestConfiguration.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/configuration/RestConfiguration.java
@@ -34,13 +34,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 @Configuration
-@EnableWebMvc
 public class RestConfiguration extends BaSyxHTTPConfiguration  {
 	
 	@Bean

--- a/basyx.submodelregistry/basyx.submodelregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/configuration/WebMvcConfig.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-service/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/configuration/WebMvcConfig.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (C) 2025 DFKI GmbH (https://www.dfki.de/en/web)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.digitaltwin.basyx.submodelregistry.service.configuration;
+
+import java.util.List;
+
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private MappingJackson2HttpMessageConverter converter;
+	
+	public WebMvcConfig(MappingJackson2HttpMessageConverter converter) {
+		this.converter = converter;
+	}
+	
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		converters.add(converter);
+	}
+
+}


### PR DESCRIPTION
refs https://github.com/eclipse-basyx/basyx-java-server-sdk/issues/630

Description:
This pull request configures the Jackson ObjectMapper to exclude null values during JSON serialization. As a result, API responses no longer include fields with null values, leading to cleaner and more efficient payloads.

Changes:

Configured Jackson2ObjectMapperBuilder to omit null properties

API responses are now free of null fields

