### PR TITLE
Fixes wrong status code for PUT AssetInformation

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/http/AasRepositoryApiHTTPController.java
+++ b/basyx.aasrepository/basyx.aasrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/http/AasRepositoryApiHTTPController.java
@@ -180,7 +180,7 @@ public class AasRepositoryApiHTTPController implements AasRepositoryHTTPApi {
 	@Override
 	public ResponseEntity<Void> putAssetInformationAasRepository(Base64UrlEncodedIdentifier aasIdentifier, @Valid AssetInformation body) {
 		aasRepository.setAssetInformation(aasIdentifier.getIdentifier(), body);
-		return new ResponseEntity<Void>(HttpStatus.OK);
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
 	}
 
 	private String getEncodedCursorFromCursorResult(CursorResult<?> cursorResult) {


### PR DESCRIPTION
## Description of Changes

The PUT AssetInformation endpoint incorrectly returned a 200 status code on a successful request instead of a 204 status. 204 is correct per specification and also makes semantically more sense since no content is returned.