### PR TITLE
Make MongoDB collection names configurable for AAS and Submodel registries

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/open-api/patch-mongodb-annotations.yaml
+++ b/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/open-api/patch-mongodb-annotations.yaml
@@ -1,7 +1,4 @@
 ---
-- op: add
-  path: /components/schemas/AssetAdministrationShellDescriptor/x-class-extra-annotation
-  value: '@org.springframework.data.mongodb.core.mapping.Document(collection = "aasdescriptors")'
 - op: add 
   path: /components/schemas/AssetAdministrationShellDescriptor/allOf/1/properties/id/x-field-extra-annotation
   value: '@org.springframework.data.annotation.Id'

--- a/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/MongoDbConfiguration.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/MongoDbConfiguration.java
@@ -32,6 +32,7 @@ import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStor
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.AasRegistryStorageFeature;
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.CursorEncodingRegistryStorage;
 import org.eclipse.digitaltwin.basyx.aasregistry.service.storage.mongodb.MongoDbAasRegistryStorage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,12 +52,15 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MongoDbConfiguration {
 
+	@Value("${basyx.aasregistry.mongodb.collectionName:submodeldescriptors}")
+	private String collectionName;
+	
 	@Bean
 	public AasRegistryStorage createStorage(MongoTemplate template, List<AasRegistryStorageFeature> features) {
 		log.info("Creating mongodb storage");
 		log.info("Creating mongodb indices");
 		initializeIndices(template);
-		AasRegistryStorage storage = new CursorEncodingRegistryStorage(new MongoDbAasRegistryStorage(template));
+		AasRegistryStorage storage = new CursorEncodingRegistryStorage(new MongoDbAasRegistryStorage(template, collectionName));
 		return applyFeatures(storage, features);
 
 	}
@@ -70,7 +74,7 @@ public class MongoDbConfiguration {
 	}
 
 	private void initializeIndices(MongoTemplate template) {
-		IndexOperations ops = template.indexOps(AssetAdministrationShellDescriptor.class);
+		IndexOperations ops = template.indexOps(collectionName);
 		initializeGetShellDescriptorsIndices(ops);
 		initializeExtensionIndices(ops);
 	}

--- a/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/MongoDbAasRegistryStorageTest.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/MongoDbAasRegistryStorageTest.java
@@ -112,7 +112,7 @@ public class MongoDbAasRegistryStorageTest extends AasRegistryStorageTest {
 	}
 
 	private void testIndexFilter(AssetKind kind, String type) {
-		MongoDbAasRegistryStorage storage = new MongoDbAasRegistryStorage(template);
+		MongoDbAasRegistryStorage storage = new MongoDbAasRegistryStorage(template, "aasdescriptors");
 		Optional<Criteria> criteriaOpt = storage.createFilterCriteria(new DescriptorFilter(kind, type));
 		assertThat(criteriaOpt).isNotEmpty();
 		Criteria criteria = criteriaOpt.get();

--- a/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/TestConfiguration.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/test/java/org/eclipse/digitaltwin/basyx/aasregistry/service/tests/TestConfiguration.java
@@ -41,7 +41,7 @@ public class TestConfiguration extends AbstractMongoClientConfiguration {
 
 	@Bean
 	public AasRegistryStorage storage(MongoTemplate template) {
-		return new CursorEncodingRegistryStorage(new MongoDbAasRegistryStorage(template));
+		return new CursorEncodingRegistryStorage(new MongoDbAasRegistryStorage(template, "aasdescriptors"));
 	}
 
 	@Bean

--- a/basyx.aasregistry/pom.xml
+++ b/basyx.aasregistry/pom.xml
@@ -116,6 +116,24 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.maven-plugin.lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 	<dependencyManagement>
 		<dependencies>

--- a/basyx.submodelregistry/basyx.submodelregistry-service-basetests/pom.xml
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-basetests/pom.xml
@@ -80,6 +80,7 @@
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>
 			<artifactId>basyx.authorization</artifactId>
 			<classifier>tests</classifier>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.digitaltwin.basyx</groupId>

--- a/basyx.submodelregistry/basyx.submodelregistry-service-basetests/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/tests/integration/AuthorizedSubmodelRegistryTestSuite.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-basetests/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/tests/integration/AuthorizedSubmodelRegistryTestSuite.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.http.HttpStatus;
+
 import org.eclipse.digitaltwin.basyx.authorization.AccessTokenProvider;
 import org.eclipse.digitaltwin.basyx.authorization.DummyCredential;
 import org.eclipse.digitaltwin.basyx.authorization.DummyCredentialStore;

--- a/basyx.submodelregistry/basyx.submodelregistry-service-mongodb-storage/open-api/patch-mongodb-annotations.yaml
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-mongodb-storage/open-api/patch-mongodb-annotations.yaml
@@ -1,7 +1,4 @@
 - op: add
-  path: /components/schemas/SubmodelDescriptor/x-class-extra-annotation
-  value: '@org.springframework.data.mongodb.core.mapping.Document(collection = "submodeldescriptors")'
-- op: add
   path: /components/schemas/SubmodelDescriptor/allOf/1/properties/id/x-field-extra-annotation
   value: '@org.springframework.data.annotation.Id'
 - op: add

--- a/basyx.submodelregistry/basyx.submodelregistry-service-mongodb-storage/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/configuration/MongoDbConfiguration.java
+++ b/basyx.submodelregistry/basyx.submodelregistry-service-mongodb-storage/src/main/java/org/eclipse/digitaltwin/basyx/submodelregistry/service/configuration/MongoDbConfiguration.java
@@ -29,6 +29,7 @@ import org.eclipse.digitaltwin.basyx.submodelregistry.service.storage.CursorEnco
 import org.eclipse.digitaltwin.basyx.submodelregistry.service.storage.SubmodelRegistryStorage;
 import org.eclipse.digitaltwin.basyx.submodelregistry.service.storage.SubmodelRegistryStorageFeature;
 import org.eclipse.digitaltwin.basyx.submodelregistry.service.storage.mongodb.MongoDbSubmodelRegistryStorage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,11 +46,15 @@ import java.util.List;
 @Log4j2
 public class MongoDbConfiguration {
 
+
+	@Value("${basyx.submodelregistry.mongodb.collectionName:submodeldescriptors}")
+	public String collectionName;
+	
 	@Bean
 	public SubmodelRegistryStorage createSubmodelRegistryStorage(MongoTemplate template, List<SubmodelRegistryStorageFeature> features) {
 		log.info("Creating mongodb storage");
 
-		SubmodelRegistryStorage storage = new CursorEncodingRegistryStorage(new MongoDbSubmodelRegistryStorage(template));
+		SubmodelRegistryStorage storage = new CursorEncodingRegistryStorage(new MongoDbSubmodelRegistryStorage(template, collectionName));
 
 		return applyFeatures(storage, features);
 	}

--- a/basyx.submodelregistry/pom.xml
+++ b/basyx.submodelregistry/pom.xml
@@ -54,8 +54,8 @@
 		<module>basyx.submodelregistry-feature-authorization</module>
 		<module>basyx.submodelregistry-feature-hierarchy</module>
 		<module>basyx.submodelregistry-feature-hierarchy-example</module>
-        <module>basyx.submodelregistry-feature-search</module>
-    </modules>
+		<module>basyx.submodelregistry-feature-search</module>
+	</modules>
 
 	<developers>
 		<developer>
@@ -102,6 +102,23 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.maven-plugin.lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 	<dependencyManagement>
 		<dependencies>
@@ -301,7 +318,8 @@
 										<contextDir>
 											${project.basedir}/src/main/docker</contextDir>
 										<buildx>
-											<platforms>${docker.target.platforms}</platforms>
+											<platforms>
+												${docker.target.platforms}</platforms>
 										</buildx>
 									</build>
 								</image>


### PR DESCRIPTION
# Description:

This MR introduces configurable properties for MongoDB collection names in the AAS Registry and Submodel Registry.
Previously, collection names were hardcoded via @Document annotations. These have been replaced by configurable properties, allowing users to override them in application.yaml while still defaulting to the existing names.

# Changes:

Added configuration properties:

basyx.aasregistry.mongodb.collectionName (default: aasdescriptors)

basyx.submodelregistry.mongodb.collectionName (default: submodeldescriptors)

Updated storage implementations to resolve collection names via configuration

Removed static @Document annotations to avoid conflicts

Retained @Id annotations for proper _id mapping in MongoDB

Adjusted Lombok configuration to ensure builds succeed with newer Java versions via Maven

# Why:
Gives users flexibility to customize collection names for different environments or deployments, and improves build compatibility with modern Java versions.

# Issue:
#873