### PR TITLE
Fixes missing leading slash in [api-docs/swagger-config/**] pattern

### DIFF
--- a/basyx.common/basyx.authorization/src/main/java/org/eclipse/digitaltwin/basyx/authorization/CommonSecurityConfiguration.java
+++ b/basyx.common/basyx.authorization/src/main/java/org/eclipse/digitaltwin/basyx/authorization/CommonSecurityConfiguration.java
@@ -52,7 +52,7 @@ public class CommonSecurityConfiguration {
 						.requestMatchers("/swagger-ui/**").permitAll()
 						.requestMatchers("/v3/**").permitAll()
 						.requestMatchers("/api-docs/**").permitAll()
-						.requestMatchers("api-docs/swagger-config/**").permitAll()
+						.requestMatchers("/api-docs/swagger-config/**").permitAll()
 						.requestMatchers(HttpMethod.GET, "/description").permitAll()
 						.anyRequest().authenticated()
 				)


### PR DESCRIPTION
Currently, the BaSyx components throw the following warning:
```
... [...] [           main] thorizationManagerRequestMatcherRegistry : One of the patterns in [api-docs/swagger-config/**] is missing a leading slash. This is discouraged; please include the leading slash in all your request matcher patterns. In future versions of Spring Security, leaving out the leading slash will result in an exception.
```

This PR fixes the missing leading slash.