### PR TITLE
Revert "Fixes default MongoDB collection name for AAS Registry"

### DIFF
--- a/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/MongoDbConfiguration.java
+++ b/basyx.aasregistry/basyx.aasregistry-service-mongodb-storage/src/main/java/org/eclipse/digitaltwin/basyx/aasregistry/service/configuration/MongoDbConfiguration.java
@@ -52,7 +52,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MongoDbConfiguration {
 
-	@Value("${basyx.aasregistry.mongodb.collectionName:aasdescriptors}")
+	@Value("${basyx.aasregistry.mongodb.collectionName:submodeldescriptors}")
 	private String collectionName;
 	
 	@Bean


### PR DESCRIPTION
Reverts eclipse-basyx/basyx-java-server-sdk#900

This is a breaking change and causes a lot of issues