### PR TITLE
Enables CORS for spring security

### DIFF
--- a/basyx.common/basyx.authorization/src/main/java/org/eclipse/digitaltwin/basyx/authorization/CommonSecurityConfiguration.java
+++ b/basyx.common/basyx.authorization/src/main/java/org/eclipse/digitaltwin/basyx/authorization/CommonSecurityConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 /**
  * Common configurations for security
@@ -43,9 +44,16 @@ import org.springframework.security.web.SecurityFilterChain;
 @ConditionalOnExpression("#{${" + CommonAuthorizationProperties.ENABLED_PROPERTY_KEY + ":false}}")
 public class CommonSecurityConfiguration {
 
+	private final CorsConfigurationSource corsConfigurationSource;
+
+	public CommonSecurityConfiguration(CorsConfigurationSource corsConfigurationSource) {
+		this.corsConfigurationSource = corsConfigurationSource;
+	}
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
+				.cors(cors -> cors.configurationSource(corsConfigurationSource))
 				.authorizeHttpRequests(authorize -> authorize
 						.requestMatchers("/actuator/health/**").permitAll()
 						.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()


### PR DESCRIPTION
## Description of Changes

This PR adds CORS to Spring security so that the same CORS settings for the individual components also apply when requests return for example a 401 or 403 status.

## Related Issue

Closes #956 