### PR TITLE
Fix Apache reverse proxy paths and context alignment in BaSyx V2 example

### DIFF
--- a/examples/BaSyxReverseProxy/apache/httpd.conf
+++ b/examples/BaSyxReverseProxy/apache/httpd.conf
@@ -1,5 +1,8 @@
 # Minimal Apache HTTP Server configuration for reverse proxy
 
+Define PORT 80
+Define HOSTNAME localhost
+
 ServerRoot "/usr/local/apache2"
 Listen ${PORT}
 ServerName ${HOSTNAME}
@@ -16,6 +19,7 @@ LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule headers_module modules/mod_headers.so
+LoadModule alias_module modules/mod_alias.so
 
 # Virtual host for reverse proxy
 <VirtualHost *:${PORT}>
@@ -23,41 +27,69 @@ LoadModule headers_module modules/mod_headers.so
         Require all granted
     </Directory>
 
-    # Configuration for the AAS Environment
-    ProxyPass /aas-environment/ http://aas-env:8081/aas-environment/
-    ProxyPassReverse /aas-environment/ http://aas-env:8081/aas-environment/
+    # -----------------------------
+    # Trailing-slash safety redirects
+    # (Avoid falling through to "/" ProxyPass when user omits trailing slash)
+    # -----------------------------
+    RedirectMatch 301 ^/aas-env$ /aas-env/
+    RedirectMatch 301 ^/aas-registry$ /aas-registry/
+    RedirectMatch 301 ^/sm-registry$ /sm-registry/
+    RedirectMatch 301 ^/aas-discovery$ /aas-discovery/
+    RedirectMatch 301 ^/aas-ui$ /aas-ui/
 
-    # Configuration for the AAS Registry
-    ProxyPass /aas-registry/ http://aas-registry:8080/aas-registry/
-    ProxyPassReverse /aas-registry/ http://aas-registry:8080/aas-registry/
+    # -----------------------------
+    # AAS Environment (compose: SERVER_SERVLET_CONTEXT_PATH=/aas-env)
+    # -----------------------------
+    ProxyPass        /aas-env/  http://aas-env:8081/aas-env/
+    ProxyPassReverse /aas-env/  http://aas-env:8081/aas-env/
 
-    # Configuration for the AAS Registry 2
-    ProxyPass /aas-registry-2/ http://aas-registry-2:8080/aas-registry-2/
-    ProxyPassReverse /aas-registry-2/ http://aas-registry-2:8080/aas-registry-2/
+    # -----------------------------
+    # AAS Registry (compose: /aas-registry)
+    # -----------------------------
+    ProxyPass        /aas-registry/  http://aas-registry:8080/aas-registry/
+    ProxyPassReverse /aas-registry/  http://aas-registry:8080/aas-registry/
 
-    # Configuration for the Submodel Registry
-    ProxyPass /sm-registry/ http://sm-registry:8080/sm-registry/
-    ProxyPassReverse /sm-registry/ http://sm-registry:8080/sm-registry/
+    # -----------------------------
+    # Submodel Registry (compose: /sm-registry)
+    # -----------------------------
+    ProxyPass        /sm-registry/  http://sm-registry:8080/sm-registry/
+    ProxyPassReverse /sm-registry/  http://sm-registry:8080/sm-registry/
 
-    # Configuration for the Submodel Registry 2
-    ProxyPass /sm-registry-2/ http://sm-registry-2:8080/sm-registry-2/
-    ProxyPassReverse /sm-registry-2/ http://sm-registry-2:8080/sm-registry-2/
+    # -----------------------------
+    # AAS Discovery Service (compose: SERVER_SERVLET_CONTEXT_PATH=/aas-discovery)
+    # -----------------------------
+    ProxyPass        /aas-discovery/  http://aas-discovery:8081/aas-discovery/
+    ProxyPassReverse /aas-discovery/  http://aas-discovery:8081/aas-discovery/
 
-    # Configuration for the AAS Discovery Service
-    ProxyPass /aas-discovery/ http://aas-discovery:8081/aas-discovery/
-    ProxyPassReverse /aas-discovery/ http://aas-discovery:8081/aas-discovery/
+    # -----------------------------
+    # AAS Web UI (compose: BASE_PATH="/aas-ui")
+    # NOTE: backend must serve under /aas-ui/
+    # -----------------------------
+    ProxyPass        /aas-ui/  http://aas-web-ui:3000/aas-ui/
+    ProxyPassReverse /aas-ui/  http://aas-web-ui:3000/aas-ui/
 
-    # Configuration for the AAS Web UI (aas-gui path)
-    ProxyPass /aas-gui/ http://aas-web-ui:3000/aas-gui/
-    ProxyPassReverse /aas-gui/ http://aas-web-ui:3000/aas-gui/
-    # Remove X-Frame-Options and Content-Security-Policy headers
+    # Optional: header tweaks for iframe embedding (keep if you need embedding)
     Header unset X-Frame-Options
     Header unset Content-Security-Policy
-    # Add custom security headers for iframe embedding
     Header always set Content-Security-Policy "frame-ancestors 'self' https://demo3.digital-twin.host"
     Header always set X-Frame-Options "ALLOW-FROM https://demo3.digital-twin.host"
 
-    # Configuration for the SPS Demonstrator UI (root path)
-    ProxyPass / http://sps-demonstrator-ui:3000/
-    ProxyPassReverse / http://sps-demonstrator-ui:3000/
+    # -----------------------------
+    # Disabled routes (not present in your docker-compose.yml)
+    # Uncomment only if you actually add these services.
+    # -----------------------------
+    # ProxyPass        /aas-registry-2/  http://aas-registry-2:8080/aas-registry-2/
+    # ProxyPassReverse /aas-registry-2/  http://aas-registry-2:8080/aas-registry-2/
+    #
+    # ProxyPass        /sm-registry-2/   http://sm-registry-2:8080/sm-registry-2/
+    # ProxyPassReverse /sm-registry-2/   http://sm-registry-2:8080/sm-registry-2/
+
+    # -----------------------------
+    # Root path reverse proxy (DISABLED)
+    # Reason: sps-demonstrator-ui is NOT defined in your compose, so it causes DNS 500.
+    # If you want a landing page, point "/" to an existing service.
+    # -----------------------------
+    # ProxyPass        /  http://sps-demonstrator-ui:3000/
+    # ProxyPassReverse /  http://sps-demonstrator-ui:3000/
+
 </VirtualHost>


### PR DESCRIPTION
Fix Apache reverse proxy configuration in BaSyx V2 example.

The original httpd.conf did not reflect the actual servlet context paths used by the BaSyx services, which caused 404 and proxy errors. This commit updates ProxyPass rules, adds trailing-slash redirects, and removes an invalid root proxy entry so that the example works as expected when deployed via docker-compose.

# Pull Request Template

## Description of Changes

This pull request fixes the Apache reverse proxy configuration in the BaSyx V2 example setup.

While following the example configuration provided in the repository, several endpoints were not reachable as documented. The main issue was a mismatch between the httpd.conf ProxyPass paths and the actual servlet context paths defined in docker-compose.yml.

The following adjustments were made:
- Updated ProxyPass routes to match the actual context paths (e.g., /aas-env instead of /aas-environment)
- Aligned the AAS Web UI proxy path with the configured BASE_PATH (/aas-ui)
- Added explicit trailing-slash redirects to prevent requests (e.g., /aas-env) from falling through to unintended proxy rules
- Disabled the root (/) ProxyPass pointing to a non-existing service, which previously caused 500 proxy errors due to DNS resolution failure

With these changes, all BaSyx components are accessible through the Apache reverse proxy as intended.

## Related Issue

No existing issue was referenced.

This pull request addresses inconsistencies observed while setting up the Apache-based BaSyx V2 example.

## BaSyx Configuration for Testing

The following setup was used for validation:
- Repository: basyx-java-server-sdk
- Docker Compose-based deployment
- Apache httpd:alpine container as reverse proxy
- BaSyx components:
  - AAS Environment (SERVER_SERVLET_CONTEXT_PATH=/aas-env)
  - AAS Registry (/aas-registry)
  - Submodel Registry (/sm-registry)
  - AAS Discovery Service (/aas-discovery)
  - AAS Web UI (BASE_PATH=/aas-ui)
Apache was configured to listen on port 80 and proxy requests via path-based routing:
- http://localhost/aas-env/
 -http://localhost/aas-registry/
 -http://localhost/sm-registry/
 -http://localhost/aas-discovery/
 -http://localhost/aas-ui/
All components were successfully accessed via the reverse proxy after applying the changes.

## AAS Files Used for Testing

he default AAS files provided in the example (./examples/BaSyxReverseProxy/aasdirectory) were used for validation.
No additional AAS files were required to reproduce or verify the issue.

## Additional Information

The issue was primarily caused by inconsistencies between:
- Documented example paths
- Servlet context paths defined in docker-compose.yml
- Apache ProxyPass configuration

Additionally, requests without trailing slashes (e.g., /aas-env) could fall through to the root proxy rule and cause DNS-related proxy errors. This has been mitigated by adding explicit redirect rules.

These changes improve stability and make the example setup work as expected when deployed using the provided Docker configuration.
