### PR TITLE
Secure repository file paths and stream downloads

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/base/DefaultAASEnvironment.java
@@ -371,7 +371,9 @@ public class DefaultAASEnvironment implements AasEnvironment {
 
 
 	private byte[] getFileContent(String submodelId, File file) throws IOException {
-		return submodelRepository.getFileByFilePath(submodelId, file.getValue()).readAllBytes();
+		try (InputStream fileContent = submodelRepository.getFileByFilePath(submodelId, file.getValue())) {
+			return fileContent.readAllBytes();
+		}
 	}
 
 	private boolean isFileAlreadyAdded(String filePath){
@@ -386,7 +388,7 @@ public class DefaultAASEnvironment implements AasEnvironment {
 				String newPath = getThumbnailPathInAASX(thumbnail.getPath());
 				relatedFiles.add(
 						new InMemoryFile(
-								Files.readAllBytes(aasRepository.getThumbnail(aasId).toPath()),
+								getThumbnailContent(aasId),
 								newPath
 						)
 				);
@@ -394,6 +396,25 @@ public class DefaultAASEnvironment implements AasEnvironment {
 			} catch (IOException | FileDoesNotExistException e) {
 				logger.error("Thumbnail file {} does not exist in the repository", thumbnail.getPath());
 			}
+		}
+	}
+
+	private byte[] getThumbnailContent(String aasId) throws IOException {
+		try (InputStream thumbnailContent = aasRepository.getThumbnailInputStream(aasId)) {
+			return thumbnailContent.readAllBytes();
+		} catch (UnsupportedOperationException e) {
+			return getThumbnailContentFromFile(aasId);
+		}
+	}
+
+	private byte[] getThumbnailContentFromFile(String aasId) throws IOException {
+		java.io.File thumbnailFile = aasRepository.getThumbnail(aasId);
+
+		try {
+			return Files.readAllBytes(thumbnailFile.toPath());
+		} finally {
+			if (thumbnailFile != null)
+				thumbnailFile.delete();
 		}
 	}
 

--- a/basyx.aasrepository/basyx.aasrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/backend/CrudAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/backend/CrudAasRepository.java
@@ -139,6 +139,11 @@ public class CrudAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return getService(aasId).getThumbnailInputStream();
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		getService(aasId).setThumbnail(fileName, contentType, inputStream);
 	}

--- a/basyx.aasrepository/basyx.aasrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/client/ConnectedAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/client/ConnectedAasRepository.java
@@ -182,6 +182,11 @@ public class ConnectedAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return getConnectedAasService(aasId).getThumbnailInputStream();
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		getConnectedAasService(aasId).setThumbnail(fileName, contentType, inputStream);
 	}

--- a/basyx.aasrepository/basyx.aasrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/AasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/AasRepository.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (C) 2023 the Eclipse BaSyx Authors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -19,12 +19,14 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 package org.eclipse.digitaltwin.basyx.aasrepository;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -34,28 +36,29 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingIdentifierException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.MissingIdentifierException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 
 /**
  * Specifies the overall AasRepository API
- * 
+ *
  * @author schnicke, kammognie
  *
  */
 public interface AasRepository {
-	
+
 	/**
 	 * Retrieves all Asset Administration Shells from the repository
-	 * 
+	 *
 	 * @return a list of all found Asset Administration Shells
 	 */
 	public CursorResult<List<AssetAdministrationShell>> getAllAas(List<SpecificAssetId> assetIds, String idShort, PaginationInfo pInfo);
 
 	/**
 	 * Retrieves a specific AAS
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS
 	 * @return the requested AAS
@@ -64,7 +67,7 @@ public interface AasRepository {
 
 	/**
 	 * Creates a new AAS at the endpoint
-	 * 
+	 *
 	 * @param aas
 	 *            the AAS to be created
 	 * @throws MissingIdentifierException
@@ -74,7 +77,7 @@ public interface AasRepository {
 
 	/**
 	 * Deletes a specific AAS
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS to be deleted
 	 */
@@ -82,14 +85,14 @@ public interface AasRepository {
 
 	/**
 	 * Overwrites an existing AAS
-	 * 
+	 *
 	 * @param aas
 	 */
 	public void updateAas(String aasId, AssetAdministrationShell aas);
 
 	/**
 	 * Returns a List of References to Submodels
-	 * 
+	 *
 	 * @param aasId
 	 * @param pInfo
 	 * @return
@@ -98,21 +101,21 @@ public interface AasRepository {
 
 	/**
 	 * Adds a Submodel Reference
-	 * 
+	 *
 	 * @param submodelReference
 	 */
 	public void addSubmodelReference(String aasId, Reference submodelReference);
 
 	/**
 	 * Removes a Submodel Reference
-	 * 
+	 *
 	 * @param submodelId
 	 */
 	public void removeSubmodelReference(String aasId, String submodelId);
 
 	/**
 	 * Sets the asset-information of a specific AAS
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS
 	 */
@@ -120,17 +123,17 @@ public interface AasRepository {
 
 	/**
 	 * Retrieves the asset-information of a specific AAS
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS
-	 * 
+	 *
 	 * @return the requested AAS
 	 */
 	public AssetInformation getAssetInformation(String aasId) throws ElementDoesNotExistException;
 
 	/**
 	 * Get Thumbnail of the specific aas
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS
 	 * @return the file of the thumbnail
@@ -138,8 +141,27 @@ public interface AasRepository {
 	public File getThumbnail(String aasId);
 
 	/**
+	 * Get Thumbnail content of the specific aas as a stream
+	 * <p>
+	 * The caller is responsible for closing the returned stream.
+	 *
+	 * @param aasId
+	 *            the id of the AAS
+	 * @return the stream of the thumbnail
+	 * @throws org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException
+	 *             if no thumbnail is stored
+	 */
+	public default InputStream getThumbnailInputStream(String aasId) {
+		try {
+			return new FileInputStream(getThumbnail(aasId));
+		} catch (FileNotFoundException e) {
+			throw new FileHandlingException("Could not open thumbnail stream.", e);
+		}
+	}
+
+	/**
 	 * Set Thumbnail of the AAS
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS
 	 * @param fileName
@@ -153,19 +175,19 @@ public interface AasRepository {
 
 	/**
 	 * Delete the thumbnail file of the AAS
-	 * 
+	 *
 	 * @param aasId
 	 *            the id of the AAS
 	 */
 	public void deleteThumbnail(String aasId);
-    
+
 	/**
 	 * Returns the name of the repository
-	 * 
+	 *
 	 * @return repoName
 	 */
 	public default String getName() {
 		return "aas-repo";
 	}
-	
+
 }

--- a/basyx.aasrepository/basyx.aasrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/AasRepositoryAasServiceWrapper.java
+++ b/basyx.aasrepository/basyx.aasrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/AasRepositoryAasServiceWrapper.java
@@ -89,6 +89,11 @@ public class AasRepositoryAasServiceWrapper implements AasService {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream() {
+		return repoApi.getThumbnailInputStream(aasId);
+	}
+
+	@Override
 	public void setThumbnail(String fileName, String contentType, InputStream inputStream) {
 		repoApi.setThumbnail(aasId, fileName, contentType, inputStream);
 

--- a/basyx.aasrepository/basyx.aasrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/authorization/AuthorizedAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/authorization/AuthorizedAasRepository.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (C) 2023 the Eclipse BaSyx Authors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -19,7 +19,7 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
@@ -62,7 +62,7 @@ public class AuthorizedAasRepository implements AasRepository {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizedAasRepository.class);
 	private AasRepository decorated;
 	private RbacPermissionResolver<AasTargetInformation> permissionResolver;
-	
+
 
 	public AuthorizedAasRepository(AasRepository decorated, RbacPermissionResolver<AasTargetInformation> permissionResolver) {
 		this.decorated = decorated;
@@ -72,15 +72,15 @@ public class AuthorizedAasRepository implements AasRepository {
 	@Override
 	public CursorResult<List<AssetAdministrationShell>> getAllAas(List<SpecificAssetId> assetIds, String idShort, PaginationInfo pInfo) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new AasTargetInformation(getIdAsList("*")));
-		
+
 		if (isAuthorized)
 			return decorated.getAllAas(assetIds, idShort, pInfo);
-		
+
 		List<TargetInformation> targetInformations = permissionResolver.getMatchingTargetInformationInRules(Action.READ, new AasTargetInformation(getIdAsList("*")));
-		
+
 		List<String> allIds = targetInformations.stream().map(AasTargetInformation.class::cast)
 				.map(AasTargetInformation::getAasIds).flatMap(List::stream).collect(Collectors.toList());
-		
+
 		List<AssetAdministrationShell> shells = allIds.stream().map(id -> {
 			try {
 				return getAas(id);
@@ -92,7 +92,7 @@ public class AuthorizedAasRepository implements AasRepository {
 				return null;
 			}
 		}).filter(Objects::nonNull).collect(Collectors.toList());
-		
+
 		TreeMap<String, AssetAdministrationShell> aasMap = shells.stream().collect(Collectors.toMap(AssetAdministrationShell::getId, aas -> aas, (a, b) -> a, TreeMap::new));
 
 		PaginationSupport<AssetAdministrationShell> paginationSupport = new PaginationSupport<>(aasMap, AssetAdministrationShell::getId);
@@ -103,120 +103,129 @@ public class AuthorizedAasRepository implements AasRepository {
 	@Override
 	public AssetAdministrationShell getAas(String shellId) throws ElementDoesNotExistException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		return decorated.getAas(shellId);
 	}
 
 	@Override
 	public void createAas(AssetAdministrationShell shell) throws CollidingIdentifierException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.CREATE, new AasTargetInformation(getIdAsList(shell.getId())));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.createAas(shell);
 	}
 
 	@Override
 	public void updateAas(String shellId, AssetAdministrationShell shell) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.updateAas(shellId, shell);
 	}
 
 	@Override
 	public void deleteAas(String shellId) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.DELETE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.deleteAas(shellId);
 	}
 
 	@Override
 	public CursorResult<List<Reference>> getSubmodelReferences(String shellId, PaginationInfo paginationInfo) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		return decorated.getSubmodelReferences(shellId, paginationInfo);
 	}
 
 	@Override
 	public void addSubmodelReference(String shellId, Reference submodelReference) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.addSubmodelReference(shellId, submodelReference);
 	}
 
 	@Override
 	public void removeSubmodelReference(String shellId, String submodelId) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.removeSubmodelReference(shellId, submodelId);
 	}
 
 	@Override
 	public void setAssetInformation(String shellId, AssetInformation shellInfo) throws ElementDoesNotExistException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.setAssetInformation(shellId, shellInfo);
 	}
 
 	@Override
 	public AssetInformation getAssetInformation(String shellId) throws ElementDoesNotExistException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		return decorated.getAssetInformation(shellId);
 	}
 
 	@Override
 	public File getThumbnail(String shellId) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		return decorated.getThumbnail(shellId);
+	}
+
+	@Override
+	public InputStream getThumbnailInputStream(String shellId) {
+		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new AasTargetInformation(getIdAsList(shellId)));
+
+		throwExceptionIfInsufficientPermission(isAuthorized);
+
+		return decorated.getThumbnailInputStream(shellId);
 	}
 
 	@Override
 	public void setThumbnail(String shellId, String fileName, String contentType, InputStream inputStream) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.setThumbnail(shellId, fileName, contentType, inputStream);
 	}
 
 	@Override
 	public void deleteThumbnail(String shellId) {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new AasTargetInformation(getIdAsList(shellId)));
-		
+
 		throwExceptionIfInsufficientPermission(isAuthorized);
-		
+
 		decorated.deleteThumbnail(shellId);
 	}
-	
+
 	@Override
 	public String getName() {
 		return decorated.getName();
 	}
-	
+
 	private ArrayList<String> getIdAsList(String id) {
 		return new ArrayList<>(Arrays.asList(id));
 	}
-	
+
 	private void throwExceptionIfInsufficientPermission(boolean isAuthorized) {
 		if (!isAuthorized)
 			throw new InsufficientPermissionException("Insufficient Permission: The current subject does not have the required permissions for this operation.");

--- a/basyx.aasrepository/basyx.aasrepository-feature-discovery-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/discoveryintegration/DiscoveryIntegrationAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-discovery-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/discoveryintegration/DiscoveryIntegrationAasRepository.java
@@ -136,6 +136,11 @@ public class DiscoveryIntegrationAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return decorated.getThumbnailInputStream(aasId);
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		decorated.setThumbnail(aasId, fileName, contentType, inputStream);
 	}

--- a/basyx.aasrepository/basyx.aasrepository-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/kafka/KafkaAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/kafka/KafkaAasRepository.java
@@ -120,6 +120,11 @@ public class KafkaAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return decorated.getThumbnailInputStream(aasId);
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		decorated.setThumbnail(aasId, fileName, contentType, inputStream);
 	}

--- a/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/mqtt/MqttAasRepository.java
@@ -196,6 +196,11 @@ public class MqttAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return decorated.getThumbnailInputStream(aasId);
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		decorated.setThumbnail(aasId, fileName, contentType, inputStream);
 	}

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
@@ -182,6 +182,11 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return decorated.getThumbnailInputStream(aasId);
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		decorated.setThumbnail(aasId, fileName, contentType, inputStream);
 	}

--- a/basyx.aasrepository/basyx.aasrepository-feature-search/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/search/SearchAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-search/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/search/SearchAasRepository.java
@@ -122,6 +122,11 @@ public class SearchAasRepository implements AasRepository {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream(String aasId) {
+		return decorated.getThumbnailInputStream(aasId);
+	}
+
+	@Override
 	public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
 		decorated.setThumbnail(aasId, fileName, contentType, inputStream);
 		reindexAAS(aasId);

--- a/basyx.aasrepository/basyx.aasrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/http/AasRepositoryApiHTTPController.java
+++ b/basyx.aasrepository/basyx.aasrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/http/AasRepositoryApiHTTPController.java
@@ -41,6 +41,7 @@ import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
 import org.eclipse.digitaltwin.basyx.aasrepository.http.pagination.GetAssetAdministrationShellsResult;
 import org.eclipse.digitaltwin.basyx.aasrepository.http.pagination.GetReferencesResult;
 import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingSubmodelReferenceException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.eclipse.digitaltwin.basyx.http.BaSyxMediaType;
@@ -49,7 +50,7 @@ import org.eclipse.digitaltwin.basyx.http.pagination.Base64UrlEncodedCursor;
 import org.eclipse.digitaltwin.basyx.http.pagination.PagedResult;
 import org.eclipse.digitaltwin.basyx.http.pagination.PagedResultPagingMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -201,12 +202,20 @@ public class AasRepositoryApiHTTPController implements AasRepositoryHTTPApi {
 	@Override
 	public ResponseEntity<Resource> getThumbnailAasRepository(Base64UrlEncodedIdentifier aasIdentifier) {
 		String aasId = aasIdentifier.getIdentifier();
-		Resource resource = new FileSystemResource(aasRepository.getThumbnail(aasId));
-		String contentType = aasRepository.getAssetInformation(aasId).getDefaultThumbnail().getContentType();
+		org.eclipse.digitaltwin.aas4j.v3.model.Resource thumbnail = aasRepository.getAssetInformation(aasId).getDefaultThumbnail();
+
+		if (!isThumbnailSet(thumbnail))
+			throw new FileDoesNotExistException();
+
+		Resource resource = new InputStreamResource(aasRepository.getThumbnailInputStream(aasId));
 
 		return ResponseEntity.ok()
-				.contentType(BaSyxMediaType.parseOrOctetStream(contentType))
+				.contentType(BaSyxMediaType.parseOrOctetStream(thumbnail.getContentType()))
 				.body(resource);
+	}
+
+	private static boolean isThumbnailSet(org.eclipse.digitaltwin.aas4j.v3.model.Resource thumbnail) {
+		return thumbnail != null && thumbnail.getPath() != null && !thumbnail.getPath().isBlank();
 	}
 
 	@Override

--- a/basyx.aasservice/basyx.aasservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/AasThumbnailOperations.java
+++ b/basyx.aasservice/basyx.aasservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/AasThumbnailOperations.java
@@ -51,23 +51,97 @@ public class AasThumbnailOperations {
         this.fileRepository = fileRepository;
     }
 
+    /**
+     * Retrieves the AAS thumbnail as a temporary local file.
+     * <p>
+     * The caller owns the returned temporary file and is responsible for deleting
+     * it when it is no longer needed.
+     *
+     * @param aasId
+     *            the id of the AAS
+     * @return the thumbnail file
+     * @throws FileDoesNotExistException
+     *             if no thumbnail is stored
+     */
     public File getThumbnail(String aasId) {
         return FileRepositoryHelper.fetchAndStoreFileLocally(fileRepository, getThumbnailResourcePathOrThrow(aasOperations.getAssetInformation(aasId)));
     }
 
-    public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
-        String filePath = FileRepositoryHelper.saveOrOverwriteFile(fileRepository, fileName, contentType, inputStream);
-       aasOperations.setAssetInformation(aasId, configureAssetInformationThumbnail(aasOperations.getAssetInformation(aasId), contentType, filePath));
+    /**
+     * Retrieves the AAS thumbnail content as a stream.
+     * <p>
+     * The caller is responsible for closing the returned stream.
+     *
+     * @param aasId
+     *            the id of the AAS
+     * @return the thumbnail content stream
+     * @throws FileDoesNotExistException
+     *             if no thumbnail is stored
+     */
+    public InputStream getThumbnailInputStream(String aasId) {
+        return FileRepositoryHelper.getFileInputStream(fileRepository, getThumbnailResourcePathOrThrow(aasOperations.getAssetInformation(aasId)));
     }
 
+    /**
+     * Stores a new AAS thumbnail and updates the thumbnail resource path.
+     *
+     * @param aasId
+     *            the id of the AAS
+     * @param fileName
+     *            the logical display name of the uploaded thumbnail
+     * @param contentType
+     *            the thumbnail MIME type
+     * @param inputStream
+     *            the thumbnail content stream
+     */
+    public void setThumbnail(String aasId, String fileName, String contentType, InputStream inputStream) {
+        AssetInformation assetInformation = aasOperations.getAssetInformation(aasId);
+        Resource oldThumbnail = assetInformation.getDefaultThumbnail();
+        String oldThumbnailPath = getThumbnailResourcePath(assetInformation).orElse(null);
+
+        FileRepositoryHelper.saveAndUpdateReference(fileRepository, oldThumbnailPath, fileName, contentType, inputStream, filePath -> setThumbnailReference(aasId, assetInformation, oldThumbnail, contentType, filePath));
+    }
+
+    /**
+     * Removes the thumbnail reference and deletes the stored thumbnail content.
+     *
+     * @param aasId
+     *            the id of the AAS
+     * @throws FileDoesNotExistException
+     *             if no thumbnail is stored
+     */
     public void deleteThumbnail(String aasId) {
         AssetInformation assetInformation = aasOperations.getAssetInformation(aasId);
-        FileRepositoryHelper.removeFileIfExists(fileRepository, getThumbnailResourcePathOrThrow(assetInformation));
-        aasOperations.setAssetInformation(aasId, configureAssetInformationThumbnail(assetInformation, "", ""));
+        Resource oldThumbnail = assetInformation.getDefaultThumbnail();
+        String thumbnailPath = getThumbnailResourcePathOrThrow(assetInformation);
+
+        FileRepositoryHelper.updateReferenceAndDeleteFile(fileRepository, thumbnailPath, () -> clearThumbnailReference(aasId, assetInformation, oldThumbnail));
+    }
+
+    private void setThumbnailReference(String aasId, AssetInformation assetInformation, Resource oldThumbnail, String contentType, String filePath) {
+        try {
+            aasOperations.setAssetInformation(aasId, configureAssetInformationThumbnail(assetInformation, contentType, filePath));
+        } catch (RuntimeException e) {
+            assetInformation.setDefaultThumbnail(oldThumbnail);
+            throw e;
+        }
+    }
+
+    private void clearThumbnailReference(String aasId, AssetInformation assetInformation, Resource oldThumbnail) {
+        try {
+            aasOperations.setAssetInformation(aasId, configureAssetInformationThumbnail(assetInformation, "", ""));
+        } catch (RuntimeException e) {
+            assetInformation.setDefaultThumbnail(oldThumbnail);
+            throw e;
+        }
     }
 
     private static String getThumbnailResourcePathOrThrow(AssetInformation assetInformation) {
-        return Optional.ofNullable(assetInformation).map(AssetInformation::getDefaultThumbnail).map(Resource::getPath).orElseThrow(FileDoesNotExistException::new);
+        return getThumbnailResourcePath(assetInformation).orElseThrow(FileDoesNotExistException::new);
+    }
+
+    private static Optional<String> getThumbnailResourcePath(AssetInformation assetInformation) {
+        return Optional.ofNullable(assetInformation).map(AssetInformation::getDefaultThumbnail).map(Resource::getPath);
     }
 
     private static AssetInformation configureAssetInformationThumbnail(AssetInformation assetInformation, String contentType, String filePath) {

--- a/basyx.aasservice/basyx.aasservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/CrudAasService.java
+++ b/basyx.aasservice/basyx.aasservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/backend/CrudAasService.java
@@ -96,6 +96,11 @@ public class CrudAasService implements AasService {
     }
 
     @Override
+    public InputStream getThumbnailInputStream() {
+        return thumbnailOperations.getThumbnailInputStream(aasId);
+    }
+
+    @Override
     public void setThumbnail(String fileName, String contentType, InputStream inputStream) {
         thumbnailOperations.setThumbnail(aasId, fileName, contentType, inputStream);
     }

--- a/basyx.aasservice/basyx.aasservice-backend/src/test/java/org/eclipse/digitaltwin/basyx/aasservice/backend/AasThumbnailOperationsTest.java
+++ b/basyx.aasservice/basyx.aasservice-backend/src/test/java/org/eclipse/digitaltwin/basyx/aasservice/backend/AasThumbnailOperationsTest.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (C) 2026 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.aasservice.backend;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.Resource;
+import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultResource;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
+import org.eclipse.digitaltwin.basyx.core.filerepository.FileMetadata;
+import org.eclipse.digitaltwin.basyx.core.filerepository.FileRepository;
+import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
+import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
+import org.junit.Test;
+
+public class AasThumbnailOperationsTest {
+
+	private static final String AAS_ID = "aas-1";
+
+	@Test
+	public void setThumbnailRejectsPathTraversalFileName() throws IOException {
+		Path victimFile = Files.createTempDirectory("basyx-victim").resolve("pwned.txt");
+		AasThumbnailOperations thumbnailOperations = new AasThumbnailOperations(new InMemoryAasOperations(), new GridFsLikeFileRepository());
+
+		try {
+			assertThrows(SecurityException.class, () -> thumbnailOperations.setThumbnail(AAS_ID, victimFile.toAbsolutePath().toString(), "image/png", new ByteArrayInputStream("payload".getBytes(UTF_8))));
+			assertFalse(Files.exists(victimFile));
+		} finally {
+			Files.deleteIfExists(victimFile.getParent());
+		}
+	}
+
+	@Test
+	public void getThumbnailWithAbsoluteResourcePathWritesOnlyTempFile() throws IOException {
+		Path victimDirectory = Files.createTempDirectory("basyx-victim");
+		Path victimFile = victimDirectory.resolve("pwned.txt");
+		String maliciousRepositoryKey = victimFile.toAbsolutePath().toString();
+		byte[] attackerPayload = "attacker bytes".getBytes(UTF_8);
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(maliciousRepositoryKey, attackerPayload);
+
+		InMemoryAasOperations aasOperations = new InMemoryAasOperations();
+		aasOperations.setAssetInformation(AAS_ID, createAssetInformationWithThumbnail(maliciousRepositoryKey));
+		AasThumbnailOperations thumbnailOperations = new AasThumbnailOperations(aasOperations, fileRepository);
+
+		try {
+			java.io.File localFile = thumbnailOperations.getThumbnail(AAS_ID);
+
+			assertTrue(localFile.exists());
+			assertNotEquals(victimFile.toAbsolutePath().toString(), localFile.toPath().toAbsolutePath().toString());
+			assertFalse(Files.exists(victimFile));
+			assertArrayEquals(attackerPayload, Files.readAllBytes(localFile.toPath()));
+			Files.deleteIfExists(localFile.toPath());
+		} finally {
+			Files.deleteIfExists(victimFile);
+			Files.deleteIfExists(victimDirectory);
+		}
+	}
+
+	@Test
+	public void getThumbnailInputStreamWithAbsoluteResourcePathDoesNotWriteToDisk() throws IOException {
+		Path victimDirectory = Files.createTempDirectory("basyx-victim");
+		Path victimFile = victimDirectory.resolve("pwned.txt");
+		String maliciousRepositoryKey = victimFile.toAbsolutePath().toString();
+		byte[] attackerPayload = "attacker bytes".getBytes(UTF_8);
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(maliciousRepositoryKey, attackerPayload);
+
+		InMemoryAasOperations aasOperations = new InMemoryAasOperations();
+		aasOperations.setAssetInformation(AAS_ID, createAssetInformationWithThumbnail(maliciousRepositoryKey));
+		AasThumbnailOperations thumbnailOperations = new AasThumbnailOperations(aasOperations, fileRepository);
+
+		try (InputStream inputStream = thumbnailOperations.getThumbnailInputStream(AAS_ID)) {
+			assertArrayEquals(attackerPayload, inputStream.readAllBytes());
+			assertFalse(Files.exists(victimFile));
+		} finally {
+			Files.deleteIfExists(victimFile);
+			Files.deleteIfExists(victimDirectory);
+		}
+	}
+
+	@Test
+	public void setThumbnailCleansNewFileAndKeepsOldFileWhenAssetInformationUpdateFails() {
+		String oldThumbnailPath = "old-thumbnail";
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(oldThumbnailPath, "old".getBytes(UTF_8));
+		FailingAasOperations aasOperations = new FailingAasOperations();
+		aasOperations.assetInformation = createAssetInformationWithThumbnail(oldThumbnailPath);
+		AasThumbnailOperations thumbnailOperations = new AasThumbnailOperations(aasOperations, fileRepository);
+
+		assertThrows(RuntimeException.class, () -> thumbnailOperations.setThumbnail(AAS_ID, "new.png", "image/png", new ByteArrayInputStream("new".getBytes(UTF_8))));
+
+		assertTrue(fileRepository.exists(oldThumbnailPath));
+		assertEquals(1, fileRepository.size());
+		assertEquals(oldThumbnailPath, aasOperations.getAssetInformation(AAS_ID).getDefaultThumbnail().getPath());
+	}
+
+	@Test
+	public void deleteThumbnailKeepsFileWhenAssetInformationUpdateFails() {
+		String oldThumbnailPath = "old-thumbnail";
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(oldThumbnailPath, "old".getBytes(UTF_8));
+		FailingAasOperations aasOperations = new FailingAasOperations();
+		aasOperations.assetInformation = createAssetInformationWithThumbnail(oldThumbnailPath);
+		AasThumbnailOperations thumbnailOperations = new AasThumbnailOperations(aasOperations, fileRepository);
+
+		assertThrows(RuntimeException.class, () -> thumbnailOperations.deleteThumbnail(AAS_ID));
+
+		assertTrue(fileRepository.exists(oldThumbnailPath));
+		assertEquals(1, fileRepository.size());
+		assertEquals(oldThumbnailPath, aasOperations.getAssetInformation(AAS_ID).getDefaultThumbnail().getPath());
+	}
+
+	private static AssetInformation createAssetInformationWithThumbnail(String path) {
+		Resource thumbnail = new DefaultResource.Builder().path(path).contentType("image/png").build();
+		AssetInformation assetInformation = new DefaultAssetInformation.Builder().build();
+		assetInformation.setDefaultThumbnail(thumbnail);
+		return assetInformation;
+	}
+
+	private static class InMemoryAasOperations implements AasOperations {
+		protected AssetInformation assetInformation = new DefaultAssetInformation.Builder().build();
+
+		@Override
+		public void setAssetInformation(String aasId, AssetInformation assetInformation) {
+			this.assetInformation = assetInformation;
+		}
+
+		@Override
+		public AssetInformation getAssetInformation(String aasId) {
+			return assetInformation;
+		}
+
+		@Override
+		public CursorResult<List<AssetAdministrationShell>> getShells(List<SpecificAssetId> assetIds, String idShort, PaginationInfo pInfo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public CursorResult<List<Reference>> getSubmodelReferences(String aasId, PaginationInfo pInfo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void addSubmodelReference(String aasId, Reference submodelReference) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void removeSubmodelReference(String aasId, String submodelId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Iterable<AssetAdministrationShell> getAllAas(List<SpecificAssetId> assetIds, String idShort) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static class FailingAasOperations extends InMemoryAasOperations {
+		@Override
+		public void setAssetInformation(String aasId, AssetInformation assetInformation) {
+			throw new RuntimeException("Could not update asset information.");
+		}
+	}
+
+	private static class GridFsLikeFileRepository implements FileRepository {
+		private final Map<String, byte[]> store = new HashMap<>();
+
+		@Override
+		public String save(FileMetadata metadata) throws FileHandlingException {
+			if (exists(metadata.getFileName()))
+				throw new FileHandlingException("File '%s' already exists.".formatted(metadata.getFileName()));
+
+			try {
+				store.put(metadata.getFileName(), metadata.getFileContent().readAllBytes());
+			} catch (IOException e) {
+				throw new FileHandlingException(metadata.getFileName(), e);
+			}
+
+			return metadata.getFileName();
+		}
+
+		@Override
+		public InputStream find(String fileId) throws FileDoesNotExistException {
+			if (!exists(fileId))
+				throw new FileDoesNotExistException();
+
+			return new ByteArrayInputStream(store.get(fileId));
+		}
+
+		@Override
+		public void delete(String fileId) throws FileDoesNotExistException {
+			if (!exists(fileId))
+				throw new FileDoesNotExistException();
+
+			store.remove(fileId);
+		}
+
+		@Override
+		public boolean exists(String fileId) {
+			return fileId != null && store.containsKey(fileId);
+		}
+
+		void put(String fileId, byte[] content) {
+			store.put(fileId, content);
+		}
+
+		int size() {
+			return store.size();
+		}
+	}
+}

--- a/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/ConnectedAasService.java
+++ b/basyx.aasservice/basyx.aasservice-client/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/client/ConnectedAasService.java
@@ -27,7 +27,10 @@
 package org.eclipse.digitaltwin.basyx.aasservice.client;
 
 import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
@@ -41,6 +44,7 @@ import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingSubmodelReferenceE
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementNotAFileException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.eclipse.digitaltwin.basyx.http.Base64UrlEncoder;
@@ -129,6 +133,11 @@ public class ConnectedAasService implements AasService {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream() {
+		return openFileAndDeleteOnClose(getThumbnail());
+	}
+
+	@Override
 	public void setThumbnail(String fileName, String contentType, InputStream inputStream) {
 		try {
 			serviceApi.putThumbnail(fileName, contentType, inputStream);
@@ -175,6 +184,23 @@ public class ConnectedAasService implements AasService {
 		}
 
 		return e;
+	}
+
+	private static InputStream openFileAndDeleteOnClose(File file) {
+		try {
+			return new FilterInputStream(Files.newInputStream(file.toPath())) {
+				@Override
+				public void close() throws IOException {
+					try {
+						super.close();
+					} finally {
+						Files.deleteIfExists(file.toPath());
+					}
+				}
+			};
+		} catch (IOException e) {
+			throw new FileHandlingException("Could not open thumbnail stream.", e);
+		}
 	}
 
 }

--- a/basyx.aasservice/basyx.aasservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/AasService.java
+++ b/basyx.aasservice/basyx.aasservice-core/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/AasService.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (C) 2023 the Eclipse BaSyx Authors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -19,24 +19,27 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 package org.eclipse.digitaltwin.basyx.aasservice;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 
 /**
  * Specifies the overall AasService API
- * 
+ *
  * @author schnicke, mateusmolina
  *
  */
@@ -44,14 +47,14 @@ public interface AasService {
 
 	/**
 	 * Retrieves the AAS contained in the server
-	 * 
+	 *
 	 * @return
 	 */
 	public AssetAdministrationShell getAAS();
 
 	/**
 	 * Retrieves all Submodel References
-	 * 
+	 *
 	 * @return A List containing all Submodel References
 	 */
 	public CursorResult<List<Reference>> getSubmodelReferences(PaginationInfo pInfo);
@@ -65,29 +68,46 @@ public interface AasService {
 	 * Removes a Submodel Reference
 	 */
 	public void removeSubmodelReference(String submodelId);
-	
+
 	/**
 	 * Sets the asset-information of the AAS contained in the server
 	 */
 	public void setAssetInformation(AssetInformation aasInfo);
-	
+
 	/**
 	 * Retrieves the asset-information of the AAS contained in the server
-	 * 
+	 *
 	 * @return the Asset-Information of the AAS
 	 */
-	public AssetInformation getAssetInformation();	
+	public AssetInformation getAssetInformation();
 
 	/**
 	 * Get Thumbnail of the specific aas
-	 * 
+	 *
 	 * @return the file of the thumbnail
 	 */
 	public File getThumbnail();
 
 	/**
+	 * Get Thumbnail content as a stream.
+	 * <p>
+	 * The caller is responsible for closing the returned stream.
+	 *
+	 * @return the stream of the thumbnail
+	 * @throws org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException
+	 *             if no thumbnail is stored
+	 */
+	public default InputStream getThumbnailInputStream() {
+		try {
+			return new FileInputStream(getThumbnail());
+		} catch (FileNotFoundException e) {
+			throw new FileHandlingException("Could not open thumbnail stream.", e);
+		}
+	}
+
+	/**
 	 * Set Thumbnail of the AAS
-	 * 
+	 *
 	 * @param fileName
 	 *            name of the thumbnail file with extension
 	 * @param contentType
@@ -99,7 +119,7 @@ public interface AasService {
 
 	/**
 	 * Delete the thumbnail file of the AAS
-	 * 
+	 *
 	 */
 	public void deleteThumbnail();
 }

--- a/basyx.aasservice/basyx.aasservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/feature/mqtt/MqttAasService.java
+++ b/basyx.aasservice/basyx.aasservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/aasservice/feature/mqtt/MqttAasService.java
@@ -191,6 +191,11 @@ public class MqttAasService implements AasService {
 	}
 
 	@Override
+	public InputStream getThumbnailInputStream() {
+		return decorated.getThumbnailInputStream();
+	}
+
+	@Override
 	public void setThumbnail(String fileName, String contentType, InputStream inputStream) {
 		decorated.setThumbnail(fileName, contentType, inputStream);
 	}

--- a/basyx.aasxfileserver/basyx.aasxfileserver-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasxfileserver/backend/CrudAASXFileServer.java
+++ b/basyx.aasxfileserver/basyx.aasxfileserver-backend/src/main/java/org/eclipse/digitaltwin/basyx/aasxfileserver/backend/CrudAASXFileServer.java
@@ -40,8 +40,8 @@ import org.eclipse.digitaltwin.basyx.aasxfileserver.AASXFileServer;
 import org.eclipse.digitaltwin.basyx.aasxfileserver.model.Package;
 import org.eclipse.digitaltwin.basyx.aasxfileserver.model.PackagesBody;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
-import org.eclipse.digitaltwin.basyx.core.filerepository.FileMetadata;
 import org.eclipse.digitaltwin.basyx.core.filerepository.FileRepository;
+import org.eclipse.digitaltwin.basyx.core.filerepository.FileRepositoryHelper;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationSupport;
@@ -96,17 +96,12 @@ public class CrudAASXFileServer implements AASXFileServer {
 
 	@Override
 	public void updateAASXByPackageId(String packageId, List<String> shellIds, InputStream file, String filename) throws ElementDoesNotExistException {
-		deleteAASXByPackageId(packageId);
+		Package existingPackage = packageBackend.findById(packageId).orElseThrow(ElementDoesNotExistException::new);
 
 		PackageDescription packageDescription = createPackageDescription(shellIds, packageId);
+		String oldFilePath = existingPackage.getPackagesBody().getFilePath();
 
-		String filepath = fileRepository.save(new FileMetadata(filename, AASX_CONTENT_TYPE, file));
-
-		PackagesBody packagesBody = createPackagesBody(shellIds, filename, filepath);
-
-		Package pkg = createPackage(packageDescription, packagesBody);
-
-		packageBackend.save(pkg);
+		saveAASXFileAndUpdatePackageReference(shellIds, file, filename, packageDescription, oldFilePath);
 	}
 
 	@Override
@@ -116,13 +111,7 @@ public class CrudAASXFileServer implements AASXFileServer {
 
 		PackageDescription packageDescription = createPackageDescription(shellIds, newpackageId);
 
-		String filepath = fileRepository.save(new FileMetadata(fileName, AASX_CONTENT_TYPE, file));
-
-		PackagesBody packagesBody = createPackagesBody(shellIds, fileName, filepath);
-
-		Package pkg = createPackage(packageDescription, packagesBody);
-
-		packageBackend.save(pkg);
+		saveAASXFileAndUpdatePackageReference(shellIds, file, fileName, packageDescription, null);
 
 		return packageDescription;
 	}
@@ -139,6 +128,13 @@ public class CrudAASXFileServer implements AASXFileServer {
 
 	private InputStream getISFromPackage(Package pkg) {
 		return fileRepository.find(pkg.getPackagesBody().getFilePath());
+	}
+
+	private void saveAASXFileAndUpdatePackageReference(List<String> shellIds, InputStream file, String fileName, PackageDescription packageDescription, String oldFilePath) {
+		FileRepositoryHelper.saveAndUpdateReference(fileRepository, oldFilePath, fileName, AASX_CONTENT_TYPE, file, filePath -> {
+			PackagesBody packagesBody = createPackagesBody(shellIds, fileName, filePath);
+			packageBackend.save(createPackage(packageDescription, packagesBody));
+		});
 	}
 
 	/**

--- a/basyx.aasxfileserver/basyx.aasxfileserver-core/src/test/java/org/eclipse/digitaltwin/basyx/aasxfileserver/core/AASXFileServerSuite.java
+++ b/basyx.aasxfileserver/basyx.aasxfileserver-core/src/test/java/org/eclipse/digitaltwin/basyx/aasxfileserver/core/AASXFileServerSuite.java
@@ -27,6 +27,7 @@ package org.eclipse.digitaltwin.basyx.aasxfileserver.core;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -93,6 +94,21 @@ public abstract class AASXFileServerSuite {
 		PackageDescription expectedPackageDescription = DummyAASXFileServerFactory.createDummyPackageDescription(actualPackageDescription.getPackageId(), DummyAASXFileServerFactory.FIRST_SHELL_IDS);
 
 		assertEquals(expectedPackageDescription, actualPackageDescription);
+	}
+
+	@Test(expected = SecurityException.class)
+	public void createAASXPackageRejectsPathTraversalFileName() {
+		AASXFileServer server = getAASXFileServer();
+
+		server.createAASXPackage(DummyAASXFileServerFactory.FIRST_SHELL_IDS, createAASXFileContent(), "../test.aasx");
+	}
+
+	@Test(expected = SecurityException.class)
+	public void updateAASXPackageRejectsPathTraversalFileName() {
+		AASXFileServer server = getAASXFileServer();
+		PackageDescription packageDescription = DummyAASXFileServerFactory.createFirstDummyAASXPackageOnServer(server);
+
+		server.updateAASXByPackageId(packageDescription.getPackageId(), DummyAASXFileServerFactory.FIRST_SHELL_IDS, createAASXFileContent(), "../test.aasx");
 	}
 
 	@Test
@@ -179,6 +195,10 @@ public abstract class AASXFileServerSuite {
 	private void updateAASXPackage(AASXFileServer server, String packageId, List<String> expectedShellIds, InputStream file, String filename) {
 
 		server.updateAASXByPackageId(packageId, expectedShellIds, file, filename);
+	}
+
+	private static InputStream createAASXFileContent() {
+		return new ByteArrayInputStream("aasx".getBytes());
 	}
 
 	private void assertGetAllAASXPackageIds(List<PackageDescription> expectedPackageDescriptions, List<PackageDescription> actualPackageDescriptions) {

--- a/basyx.common/basyx.filerepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelper.java
+++ b/basyx.common/basyx.filerepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelper.java
@@ -26,10 +26,13 @@
 package org.eclipse.digitaltwin.basyx.core.filerepository;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
@@ -40,69 +43,218 @@ import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
  * @author mateusmolina
  */
 public class FileRepositoryHelper {
+    private static final int MAX_EXTENSION_LENGTH = 16;
+
 
     private FileRepositoryHelper() {
     }
 
     /**
-     * Retrieves the content of a file from the repository and creates a local file.
+     * Retrieves repository content and materializes it as a temporary local file.
+     * <p>
+     * The repository id is never used as a filesystem path. The caller owns the
+     * returned temporary file and is responsible for deleting it when it is no
+     * longer needed.
      *
      * @param fileRepository
      *            the file repository instance
      * @param filePath
+     *            the repository file id
      * @return the retrieved file
      * @throws FileHandlingException
      *             if an IO error occurs
      */
     public static File fetchAndStoreFileLocally(FileRepository fileRepository, String filePath) {
+        Path temporaryFile = null;
+
         try (InputStream fileIs = fileRepository.find(filePath)) {
-            byte[] content = fileIs.readAllBytes();
-            writeToFile(filePath, content);
-            return new File(filePath);
+            temporaryFile = Files.createTempFile("basyx-file-", ".tmp");
+            Files.copy(fileIs, temporaryFile, StandardCopyOption.REPLACE_EXISTING);
+            return temporaryFile.toFile();
         } catch (IOException e) {
+            deleteIfExists(temporaryFile);
             throw new FileHandlingException("Error while retrieving file content:" + filePath, e);
         }
     }
 
     /**
-     * Writes byte content to a file on disk.
-     *
-     * @param filePath
-     *            the path where the file should be created
-     * @param content
-     *            the byte content to be written to the file
-     * @throws FileHandlingException
-     *             if an IO error occurs
-     */
-    public static void writeToFile(String filePath, byte[] content) {
-        try (OutputStream outputStream = new FileOutputStream(filePath)) {
-            outputStream.write(content);
-        } catch (IOException e) {
-            throw new FileHandlingException("Error while writing to file: " + filePath, e);
-        }
-    }
-
-    /**
-     * Saves a file to the repository, deleting any existing file with the same
-     * name.
+     * Saves a file to the repository under a server-generated id.
+     * <p>
+     * The supplied {@code fileName} is treated as a logical display name only. It
+     * must not be blank, contain control characters, contain path separators,
+     * contain {@code ..}, or start with a Windows drive prefix. The stored file id
+     * is a UUID plus a conservative ASCII alphanumeric extension, if one is
+     * present.
      *
      * @param fileRepository
      *            the file repository instance
      * @param fileName
-     *            the name of the file
+     *            the logical name of the file
      * @param contentType
      *            the MIME type of the file
      * @param inputStream
      *            the input stream containing file data
-     * @return the path where the file is saved
+     * @return the generated repository file id
+     * @throws IllegalArgumentException
+     *             if the logical filename is null, blank, or contains control
+     *             characters
+     * @throws SecurityException
+     *             if the logical filename looks like a path traversal attempt
      */
     public static String saveOrOverwriteFile(FileRepository fileRepository, String fileName, String contentType, InputStream inputStream) {
-        FileMetadata fileMetadata = new FileMetadata(fileName, contentType, inputStream);
+        String logicalFileName = validateLogicalFileName(fileName);
+        String storedFileName = createUniqueFileName(logicalFileName);
+        FileMetadata fileMetadata = new FileMetadata(storedFileName, logicalFileName, contentType, inputStream);
 
-        if (fileRepository.exists(fileName)) {
-            fileRepository.delete(fileName);
+        if (fileRepository.exists(storedFileName)) {
+            fileRepository.delete(storedFileName);
         }
         return fileRepository.save(fileMetadata);
+    }
+
+    /**
+     * Saves a new file, updates its owning domain reference, and then removes the
+     * old repository file on success.
+     * <p>
+     * If {@code updateReference} fails, the newly saved repository file is deleted
+     * before the exception is rethrown.
+     *
+     * @param fileRepository
+     *            the file repository instance
+     * @param oldFilePath
+     *            the previous repository file id, or null if none exists
+     * @param fileName
+     *            the logical display name of the uploaded file
+     * @param contentType
+     *            the MIME type of the file
+     * @param inputStream
+     *            the input stream containing file data
+     * @param updateReference
+     *            callback that stores the new repository file id in the owning
+     *            domain object
+     * @return the generated repository file id
+     */
+    public static String saveAndUpdateReference(FileRepository fileRepository, String oldFilePath, String fileName, String contentType, InputStream inputStream, Consumer<String> updateReference) {
+        String filePath = saveOrOverwriteFile(fileRepository, fileName, contentType, inputStream);
+
+        try {
+            updateReference.accept(filePath);
+        } catch (RuntimeException e) {
+            deleteFileIfExists(fileRepository, filePath);
+            throw e;
+        }
+
+        deleteFileIfExists(fileRepository, oldFilePath);
+
+        return filePath;
+    }
+
+    /**
+     * Updates the owning domain reference to no longer point at a repository file
+     * and then removes that repository file on success.
+     *
+     * @param fileRepository
+     *            the file repository instance
+     * @param filePath
+     *            the repository file id to delete
+     * @param updateReference
+     *            callback that clears the owning domain reference
+     * @throws FileDoesNotExistException
+     *             if {@code filePath} does not exist in the repository
+     */
+    public static void updateReferenceAndDeleteFile(FileRepository fileRepository, String filePath, Runnable updateReference) {
+        if (!fileRepository.exists(filePath))
+            throw new FileDoesNotExistException();
+
+        updateReference.run();
+
+        deleteFileIfExists(fileRepository, filePath);
+    }
+
+    /**
+     * Opens repository content as a stream. The caller must close the returned
+     * stream.
+     *
+     * @param fileRepository
+     *            the file repository instance
+     * @param filePath
+     *            the repository file id
+     * @return the repository content stream
+     * @throws FileDoesNotExistException
+     *             if {@code filePath} does not exist in the repository
+     */
+    public static InputStream getFileInputStream(FileRepository fileRepository, String filePath) {
+        return fileRepository.find(filePath);
+    }
+
+    /**
+     * Best-effort deletion of a repository file.
+     *
+     * @param fileRepository
+     *            the file repository instance
+     * @param filePath
+     *            the repository file id
+     */
+    public static void deleteFileIfExists(FileRepository fileRepository, String filePath) {
+        if (filePath == null)
+            return;
+
+        try {
+            if (fileRepository.exists(filePath))
+                fileRepository.delete(filePath);
+        } catch (FileDoesNotExistException e) {
+        }
+    }
+
+    private static String createUniqueFileName(String logicalFileName) {
+        return UUID.randomUUID() + getFileExtension(logicalFileName);
+    }
+
+    private static String getFileExtension(String fileName) {
+        int extensionStart = fileName.lastIndexOf('.');
+
+        if (extensionStart <= 0 || extensionStart >= fileName.length() - 1)
+            return "";
+
+        String extension = fileName.substring(extensionStart + 1);
+
+        if (extension.length() > MAX_EXTENSION_LENGTH || !extension.chars().allMatch(FileRepositoryHelper::isAsciiLetterOrDigit))
+            return "";
+
+        return "." + extension;
+    }
+
+    private static boolean isAsciiLetterOrDigit(int character) {
+        return character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9';
+    }
+
+    private static String validateLogicalFileName(String fileName) {
+        if (fileName == null || fileName.isBlank())
+            throw new IllegalArgumentException("File name must not be null or blank.");
+
+        String logicalFileName = fileName.replace("\r", "_").replace("\n", "_").trim();
+
+        if (logicalFileName.chars().anyMatch(Character::isISOControl))
+            throw new IllegalArgumentException("File name must not contain control characters.");
+
+        if (logicalFileName.contains("..") || logicalFileName.contains("/") || logicalFileName.contains("\\") || startsWithWindowsDrivePrefix(logicalFileName))
+            throw new SecurityException("Path traversal attempt detected.");
+
+        return logicalFileName;
+    }
+
+    private static boolean startsWithWindowsDrivePrefix(String fileName) {
+        return fileName.length() >= 2 && Character.isLetter(fileName.charAt(0)) && fileName.charAt(1) == ':';
+    }
+
+    private static void deleteIfExists(Path path) {
+        if (path == null)
+            return;
+
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+        }
     }
 
     /**
@@ -111,7 +263,7 @@ public class FileRepositoryHelper {
      * @param fileRepository
      *            the file repository instance
      * @param filePath
-     *            the path of the file to be deleted
+     *            the repository file id to delete
      * @throws FileDoesNotExistException
      *             if the file does not exist
      */

--- a/basyx.common/basyx.filerepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelper.java
+++ b/basyx.common/basyx.filerepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelper.java
@@ -52,9 +52,10 @@ public class FileRepositoryHelper {
     /**
      * Retrieves repository content and materializes it as a temporary local file.
      * <p>
-     * The repository id is never used as a filesystem path. The caller owns the
-     * returned temporary file and is responsible for deleting it when it is no
-     * longer needed.
+     * The repository id is never used as a filesystem path. A conservative file
+     * extension is preserved for compatibility with callers that inspect the
+     * returned file name. The caller owns the returned temporary file and is
+     * responsible for deleting it when it is no longer needed.
      *
      * @param fileRepository
      *            the file repository instance
@@ -68,7 +69,7 @@ public class FileRepositoryHelper {
         Path temporaryFile = null;
 
         try (InputStream fileIs = fileRepository.find(filePath)) {
-            temporaryFile = Files.createTempFile("basyx-file-", ".tmp");
+            temporaryFile = Files.createTempFile("basyx-file-", getSafeTempFileSuffix(filePath));
             Files.copy(fileIs, temporaryFile, StandardCopyOption.REPLACE_EXISTING);
             return temporaryFile.toFile();
         } catch (IOException e) {
@@ -211,6 +212,9 @@ public class FileRepositoryHelper {
     }
 
     private static String getFileExtension(String fileName) {
+        if (fileName == null)
+            return "";
+
         int extensionStart = fileName.lastIndexOf('.');
 
         if (extensionStart <= 0 || extensionStart >= fileName.length() - 1)
@@ -222,6 +226,15 @@ public class FileRepositoryHelper {
             return "";
 
         return "." + extension;
+    }
+
+    private static String getSafeTempFileSuffix(String filePath) {
+        String extension = getFileExtension(filePath);
+
+        if (extension.isEmpty())
+            return ".tmp";
+
+        return extension;
     }
 
     private static boolean isAsciiLetterOrDigit(int character) {

--- a/basyx.common/basyx.filerepository-backend/src/test/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelperTest.java
+++ b/basyx.common/basyx.filerepository-backend/src/test/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelperTest.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (C) 2026 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.core.filerepository;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
+import org.junit.Test;
+
+public class FileRepositoryHelperTest {
+
+	@Test
+	public void saveOrOverwriteFileRejectsPathTraversalFileName() throws IOException {
+		Path victimFile = Files.createTempDirectory("basyx-victim").resolve("pwned.txt");
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+
+		try {
+			assertThrows(SecurityException.class, () -> FileRepositoryHelper.saveOrOverwriteFile(fileRepository, victimFile.toAbsolutePath().toString(), "text/plain", content("payload")));
+			assertFalse(Files.exists(victimFile));
+		} finally {
+			Files.deleteIfExists(victimFile.getParent());
+		}
+	}
+
+	@Test
+	public void saveOrOverwriteFileUsesGeneratedStorageIdAndPreservesOriginalName() {
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+
+		String storedId = FileRepositoryHelper.saveOrOverwriteFile(fileRepository, "thumbnail.png", "image/png", content("payload"));
+
+		assertNotEquals("thumbnail.png", storedId);
+		assertTrue(storedId.matches("[0-9a-fA-F\\-]{36}\\.png"));
+		assertTrue(fileRepository.exists(storedId));
+		assertEquals("thumbnail.png", fileRepository.getOriginalFileName(storedId));
+		assertArrayEquals("payload".getBytes(UTF_8), fileRepository.content(storedId));
+	}
+
+	@Test
+	public void saveOrOverwriteFileDropsUnsafeExtensionFromStorageId() {
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+
+		String storedId = FileRepositoryHelper.saveOrOverwriteFile(fileRepository, "thumbnail.pn:g", "image/png", content("payload"));
+
+		assertTrue(storedId.matches("[0-9a-fA-F\\-]{36}"));
+		assertTrue(fileRepository.exists(storedId));
+		assertEquals("thumbnail.pn:g", fileRepository.getOriginalFileName(storedId));
+	}
+
+	@Test
+	public void saveOrOverwriteFileDropsLongExtensionFromStorageId() {
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+
+		String storedId = FileRepositoryHelper.saveOrOverwriteFile(fileRepository, "thumbnail.abcdefghijklmnopq", "image/png", content("payload"));
+
+		assertTrue(storedId.matches("[0-9a-fA-F\\-]{36}"));
+		assertTrue(fileRepository.exists(storedId));
+		assertEquals("thumbnail.abcdefghijklmnopq", fileRepository.getOriginalFileName(storedId));
+	}
+
+	@Test
+	public void saveOrOverwriteFileRejectsControlCharacterFileName() {
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+
+		assertThrows(IllegalArgumentException.class, () -> FileRepositoryHelper.saveOrOverwriteFile(fileRepository, "thumbnail.pn\0g", "image/png", content("payload")));
+	}
+
+	@Test
+	public void fetchAndStoreFileLocallyDoesNotUseRepositoryKeyAsFilesystemPath() throws IOException {
+		Path victimDirectory = Files.createTempDirectory("basyx-victim");
+		Path victimFile = victimDirectory.resolve("pwned.txt");
+		String maliciousRepositoryKey = victimFile.toAbsolutePath().toString();
+		byte[] attackerPayload = "attacker bytes".getBytes(UTF_8);
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(maliciousRepositoryKey, attackerPayload);
+
+		try {
+			java.io.File localFile = FileRepositoryHelper.fetchAndStoreFileLocally(fileRepository, maliciousRepositoryKey);
+
+			assertTrue(localFile.exists());
+			assertNotEquals(victimFile.toAbsolutePath().toString(), localFile.toPath().toAbsolutePath().toString());
+			assertFalse(Files.exists(victimFile));
+			assertArrayEquals(attackerPayload, Files.readAllBytes(localFile.toPath()));
+			Files.deleteIfExists(localFile.toPath());
+		} finally {
+			Files.deleteIfExists(victimFile);
+			Files.deleteIfExists(victimDirectory);
+		}
+	}
+
+	private static ByteArrayInputStream content(String content) {
+		return new ByteArrayInputStream(content.getBytes(UTF_8));
+	}
+
+	private static class GridFsLikeFileRepository implements FileRepository {
+		private final Map<String, StoredFile> store = new HashMap<>();
+
+		@Override
+		public String save(FileMetadata metadata) throws FileHandlingException {
+			if (exists(metadata.getFileName()))
+				throw new FileHandlingException("File '%s' already exists.".formatted(metadata.getFileName()));
+
+			try {
+				put(metadata.getFileName(), metadata.getOriginalFileName(), metadata.getFileContent().readAllBytes());
+			} catch (IOException e) {
+				throw new FileHandlingException(metadata.getFileName(), e);
+			}
+
+			return metadata.getFileName();
+		}
+
+		@Override
+		public InputStream find(String fileId) throws FileDoesNotExistException {
+			if (!exists(fileId))
+				throw new FileDoesNotExistException();
+
+			return new ByteArrayInputStream(content(fileId));
+		}
+
+		@Override
+		public void delete(String fileId) throws FileDoesNotExistException {
+			if (!exists(fileId))
+				throw new FileDoesNotExistException();
+
+			store.remove(fileId);
+		}
+
+		@Override
+		public boolean exists(String fileId) {
+			return fileId != null && store.containsKey(fileId);
+		}
+
+		@Override
+		public String getOriginalFileName(String fileId) {
+			return store.get(fileId).originalFileName;
+		}
+
+		void put(String fileId, byte[] content) {
+			put(fileId, fileId, content);
+		}
+
+		void put(String fileId, String originalFileName, byte[] content) {
+			store.put(fileId, new StoredFile(originalFileName, content));
+		}
+
+		byte[] content(String fileId) {
+			return store.get(fileId).content;
+		}
+	}
+
+	private static class StoredFile {
+		private final String originalFileName;
+		private final byte[] content;
+
+		StoredFile(String originalFileName, byte[] content) {
+			this.originalFileName = originalFileName;
+			this.content = content;
+		}
+	}
+}

--- a/basyx.common/basyx.filerepository-backend/src/test/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelperTest.java
+++ b/basyx.common/basyx.filerepository-backend/src/test/java/org/eclipse/digitaltwin/basyx/core/filerepository/FileRepositoryHelperTest.java
@@ -115,6 +115,7 @@ public class FileRepositoryHelperTest {
 			java.io.File localFile = FileRepositoryHelper.fetchAndStoreFileLocally(fileRepository, maliciousRepositoryKey);
 
 			assertTrue(localFile.exists());
+			assertTrue(localFile.getName().endsWith(".txt"));
 			assertNotEquals(victimFile.toAbsolutePath().toString(), localFile.toPath().toAbsolutePath().toString());
 			assertFalse(Files.exists(victimFile));
 			assertArrayEquals(attackerPayload, Files.readAllBytes(localFile.toPath()));

--- a/basyx.submodelrepository/basyx.submodelrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/backend/CrudSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/backend/CrudSubmodelRepository.java
@@ -188,6 +188,11 @@ public class CrudSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return getService(submodelId).getFileByPathAsStream(idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		getService(submodelId).setFileValue(idShortPath, fileName, contentType, inputStream);
 	}

--- a/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/ConnectedSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/client/ConnectedSubmodelRepository.java
@@ -236,6 +236,11 @@ public class ConnectedSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return getConnectedSubmodelService(submodelId).getFileByPathAsStream(idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		getConnectedSubmodelService(submodelId).setFileValue(idShortPath, fileName, contentType, inputStream);
 	}

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/SubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/SubmodelRepository.java
@@ -25,6 +25,8 @@
 
 package org.eclipse.digitaltwin.basyx.submodelrepository;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -35,6 +37,7 @@ import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingIdentifierExceptio
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementNotAFileException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.MissingIdentifierException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
@@ -231,7 +234,10 @@ public interface SubmodelRepository {
 	public Submodel getSubmodelByIdMetadata(String submodelId) throws ElementDoesNotExistException;
 
 	/**
-	 * Retrieves the file of a file submodelelement
+	 * Retrieves the file of a file submodelelement.
+	 * <p>
+	 * Implementations that materialize repository content as a temporary file must
+	 * document whether the caller is responsible for deleting the returned file.
 	 * 
 	 * @param submodelId
 	 *            the Submodel id
@@ -244,6 +250,33 @@ public interface SubmodelRepository {
 	 * @throws FileDoesNotExistException
 	 */
 	public java.io.File getFileByPathSubmodel(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException;
+
+	/**
+	 * Retrieves the content of a file submodel element as a stream.
+	 * <p>
+	 * The file is resolved by submodel id and submodel element idShort path, not by
+	 * the repository storage id. The caller is responsible for closing the returned
+	 * stream.
+	 *
+	 * @param submodelId
+	 *            the Submodel id
+	 * @param idShortPath
+	 *            the IdShort path of the file element
+	 * @return File InputStream
+	 * @throws ElementDoesNotExistException
+	 *             if the SubmodelElement does not exist
+	 * @throws ElementNotAFileException
+	 *             if the SubmodelElement is not a File
+	 * @throws FileDoesNotExistException
+	 *             if the referenced file content does not exist
+	 */
+	public default InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		try {
+			return new FileInputStream(getFileByPathSubmodel(submodelId, idShortPath));
+		} catch (FileNotFoundException e) {
+			throw new FileHandlingException("Could not open file stream.", e);
+		}
+	}
 
 	/**
 	 * Uploads a file to a file submodelelement
@@ -288,13 +321,15 @@ public interface SubmodelRepository {
 	public void patchSubmodelElements(String submodelId, List<SubmodelElement> submodelElementList);
 
 	/**
-	 * Retrieves the file of a file submodelelement via its absolute path
+	 * Retrieves file content by repository storage id.
 	 *
 	 * @param submodelId
 	 * 			  the Submodel id
 	 * @param filePath
-	 *            the path of the file
+	 *            the repository file id
 	 * @return File InputStream
+	 * @throws FileDoesNotExistException
+	 *             if the repository file id does not exist
 	 */
 	public InputStream getFileByFilePath(String submodelId, String filePath);
 

--- a/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositorySubmodelServiceWrapper.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-core/src/test/java/org/eclipse/digitaltwin/basyx/submodelrepository/core/SubmodelRepositorySubmodelServiceWrapper.java
@@ -125,6 +125,11 @@ public class SubmodelRepositorySubmodelServiceWrapper implements SubmodelService
 	}
 
 	@Override
+	public InputStream getFileByPathAsStream(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return repoApi.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		repoApi.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 	}

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/authorization/AuthorizedSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/authorization/AuthorizedSubmodelRepository.java
@@ -278,6 +278,15 @@ public class AuthorizedSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new SubmodelTargetInformation(getIdAsList(submodelId), getIdAsList(idShortPath)));
+
+		throwExceptionIfInsufficientPermission(isAuthorized);
+
+		return decorated.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.UPDATE, new SubmodelTargetInformation(getIdAsList(submodelId), getIdAsList(idShortPath)));
 
@@ -306,6 +315,10 @@ public class AuthorizedSubmodelRepository implements SubmodelRepository {
 
 	@Override
 	public InputStream getFileByFilePath(String submodelId, String filePath) {
+		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new SubmodelTargetInformation(getIdAsList(submodelId), getIdAsList(filePath)));
+
+		throwExceptionIfInsufficientPermission(isAuthorized);
+
 		return decorated.getFileByFilePath(submodelId, filePath);
 	}
 

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/kafka/KafkaSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/kafka/KafkaSubmodelRepository.java
@@ -175,6 +175,11 @@ public class KafkaSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) {
+		return decorated.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void deleteFileValue(String identifier, String idShortPath) {
 		decorated.deleteFileValue(identifier, idShortPath);
 	}

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/MqttSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/mqtt/MqttSubmodelRepository.java
@@ -184,6 +184,11 @@ public class MqttSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) {
+		return decorated.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void deleteFileValue(String identifier, String idShortPath) {
 		SubmodelElement submodelElement = decorated.getSubmodelElement(identifier, idShortPath);	
 		decorated.deleteFileValue(identifier, idShortPath);

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-operation-delegation/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/operation/delegation/OperationDelegationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-operation-delegation/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/operation/delegation/OperationDelegationSubmodelRepository.java
@@ -159,6 +159,11 @@ public class OperationDelegationSubmodelRepository implements SubmodelRepository
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return decorated.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 		

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/registry/integration/RegistryIntegrationSubmodelRepository.java
@@ -174,6 +174,11 @@ public class RegistryIntegrationSubmodelRepository implements SubmodelRepository
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return decorated.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 	}

--- a/basyx.submodelrepository/basyx.submodelrepository-feature-search/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/search/SearchSubmodelRepository.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-feature-search/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/feature/search/SearchSubmodelRepository.java
@@ -157,6 +157,11 @@ public class SearchSubmodelRepository implements SubmodelRepository {
 	}
 
 	@Override
+	public InputStream getFileByPathSubmodelAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return decorated.getFileByPathSubmodelAsStream(submodelId, idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		decorated.setFileValue(submodelId, idShortPath, fileName, contentType, inputStream);
 		reindexSM(submodelId);

--- a/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
+++ b/basyx.submodelrepository/basyx.submodelrepository-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelrepository/http/SubmodelRepositoryApiHTTPController.java
@@ -60,8 +60,9 @@ import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelElementListVa
 import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelElementValue;
 import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelValueOnly;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -232,15 +233,17 @@ public class SubmodelRepositoryApiHTTPController implements SubmodelRepositoryHT
 	@Override
 	public ResponseEntity<Resource> getFileByPath(Base64UrlEncodedIdentifier submodelIdentifier, String idShortPath) {
 		String submodelId = submodelIdentifier.getIdentifier();
-		java.io.File file = repository.getFileByPathSubmodel(submodelId, idShortPath);
-		Resource resource = new FileSystemResource(file);
-		org.eclipse.digitaltwin.aas4j.v3.model.File fileSubmodelElement = (org.eclipse.digitaltwin.aas4j.v3.model.File) repository.getSubmodelElement(submodelId, idShortPath);
+		SubmodelElement submodelElement = repository.getSubmodelElement(submodelId, idShortPath);
+
+		if (!(submodelElement instanceof org.eclipse.digitaltwin.aas4j.v3.model.File fileSubmodelElement))
+			throw new ElementNotAFileException(submodelElement.getIdShort());
 
 		String fileName = repository.getOriginalFileNameByPath(submodelId, idShortPath);
+		Resource resource = new InputStreamResource(repository.getFileByPathSubmodelAsStream(submodelId, idShortPath));
 
 		return ResponseEntity.ok()
 				.contentType(BaSyxMediaType.parseOrOctetStream(fileSubmodelElement.getContentType()))
-				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"")
+				.header(HttpHeaders.CONTENT_DISPOSITION, ContentDisposition.attachment().filename(fileName).build().toString())
 				.body(resource);
 	}
 

--- a/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/CrudSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/CrudSubmodelService.java
@@ -44,9 +44,8 @@ import org.springframework.lang.NonNull;
 
 import java.io.File;
 import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Default {@link SubmodelService} based on {@link SubmodelBackend}
@@ -113,7 +112,7 @@ public class CrudSubmodelService implements SubmodelService {
         boolean newSubmodelElementIsFile = newElement instanceof org.eclipse.digitaltwin.aas4j.v3.model.File;
 
         if (existingSubmodelElementIsFile && newSubmodelElementIsFile) {
-            handleFileAttachmentUpdate(submodelId, idShortPath, newElement);
+            handleFileAttachmentUpdate(idShortPath, existingSubmodelElement, newElement);
         } else if (existingSubmodelElementIsFile) {
             deleteAssociatedFileIfAny(idShortPath);
         }
@@ -121,9 +120,9 @@ public class CrudSubmodelService implements SubmodelService {
         backend.updateSubmodelElement(submodelId, idShortPath, newElement);
     }
 
-    private void handleFileAttachmentUpdate(String submodelId, String idShortPath, SubmodelElement updatedElement) {
+    private void handleFileAttachmentUpdate(String idShortPath, SubmodelElement existingElement, SubmodelElement updatedElement) {
         try {
-            if (hasFilePathChanged(submodelId, idShortPath, updatedElement)) {
+            if (hasFilePathChanged(existingElement, updatedElement)) {
                 deleteAssociatedFileIfAny(idShortPath);
             }
         } catch (Exception e) {
@@ -132,52 +131,23 @@ public class CrudSubmodelService implements SubmodelService {
         }
     }
 
-    private boolean hasFilePathChanged(String submodelId, String idShortPath, SubmodelElement updatedElement) {
+    private boolean hasFilePathChanged(SubmodelElement existingElement, SubmodelElement updatedElement) {
+        if (!(existingElement instanceof org.eclipse.digitaltwin.aas4j.v3.model.File existingFile)) {
+            logger.warn("Expected File element but got: {}", existingElement.getClass().getSimpleName());
+            return true;
+        }
+
         if (!(updatedElement instanceof org.eclipse.digitaltwin.aas4j.v3.model.File file)) {
             logger.warn("Expected File element but got: {}", updatedElement.getClass().getSimpleName());
             return true;
         }
 
-        String newPathString = extractFilePath(file);
-        if (newPathString == null) {
-            return true;
-        }
-
-        String oldPathString = getExistingFilePath(submodelId, idShortPath);
-        if (oldPathString == null) {
-            return true;
-        }
-
-        return pathsDiffer(oldPathString, newPathString);
-    }
-
-    private boolean isFileElement(SubmodelElement element) {
-        return element instanceof org.eclipse.digitaltwin.aas4j.v3.model.File;
+        return !Objects.equals(extractFilePath(existingFile), extractFilePath(file));
     }
 
     // Extracts the new file path (value) from the updated File element
     private String extractFilePath(org.eclipse.digitaltwin.aas4j.v3.model.File fileElement) {
         return fileElement.getValue();
-    }
-
-    private String getExistingFilePath(String submodelId, String idShortPath) {
-        try {
-            return submodelFileOperations.getFile(submodelId, idShortPath).getPath();
-        } catch (Exception e) {
-            logger.warn("Failed to retrieve existing file path for '{}': {}", idShortPath, e.getMessage(), e);
-            return null;
-        }
-    }
-
-    private boolean pathsDiffer(String path1, String path2) {
-        try {
-            Path normalized1 = Paths.get(path1).normalize().toAbsolutePath();
-            Path normalized2 = Paths.get(path2).normalize().toAbsolutePath();
-            return !normalized1.equals(normalized2);
-        } catch (Exception e) {
-            logger.error("Error comparing file paths: {}", e.getMessage(), e);
-            return true; // Consider paths different in case of error
-        }
     }
 
     @Override
@@ -205,6 +175,11 @@ public class CrudSubmodelService implements SubmodelService {
     @Override
     public File getFileByPath(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
         return submodelFileOperations.getFile(submodelId, idShortPath);
+    }
+
+    @Override
+    public InputStream getFileByPathAsStream(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+        return submodelFileOperations.getFileAsStream(submodelId, idShortPath);
     }
 
     @Override

--- a/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/SubmodelFileOperations.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/SubmodelFileOperations.java
@@ -25,20 +25,15 @@
 
 package org.eclipse.digitaltwin.basyx.submodelservice.backend;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.UUID;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.File;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementNotAFileException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
-import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
-import org.eclipse.digitaltwin.basyx.core.filerepository.FileMetadata;
 import org.eclipse.digitaltwin.basyx.core.filerepository.FileRepository;
+import org.eclipse.digitaltwin.basyx.core.filerepository.FileRepositoryHelper;
 import org.eclipse.digitaltwin.basyx.submodelservice.value.FileBlobValue;
 
 /**
@@ -55,6 +50,24 @@ public class SubmodelFileOperations  {
         this.submodelOperations = operations;
     }
 
+	/**
+	 * Retrieves a file submodel element's content as a temporary local file.
+	 * <p>
+	 * The caller owns the returned temporary file and is responsible for deleting
+	 * it when it is no longer needed.
+	 *
+	 * @param submodelId
+	 *            the id of the Submodel
+	 * @param idShortPath
+	 *            the idShort path of the file element
+	 * @return the file content materialized as a temporary file
+	 * @throws ElementDoesNotExistException
+	 *             if the SubmodelElement does not exist
+	 * @throws ElementNotAFileException
+	 *             if the SubmodelElement is not a File
+	 * @throws FileDoesNotExistException
+	 *             if the referenced file content does not exist
+	 */
 	public java.io.File getFile(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
 		SubmodelElement submodelElement = submodelOperations.getSubmodelElement(submodelId, idShortPath);
 
@@ -63,36 +76,84 @@ public class SubmodelFileOperations  {
 		File fileSmElement = (File) submodelElement;
 		String filePath = getFilePath(fileSmElement);
 
-		InputStream fileContent = getFileInputStream(filePath);
-
-		return createFile(filePath, fileContent);
+		return FileRepositoryHelper.fetchAndStoreFileLocally(fileRepository, filePath);
 	}
 
+	/**
+	 * Retrieves a file submodel element's content as a stream.
+	 * <p>
+	 * The file is resolved by submodel id and element idShort path, not by the
+	 * repository storage id. The caller is responsible for closing the returned
+	 * stream.
+	 *
+	 * @param submodelId
+	 *            the id of the Submodel
+	 * @param idShortPath
+	 *            the idShort path of the file element
+	 * @return the file content stream
+	 * @throws ElementDoesNotExistException
+	 *             if the SubmodelElement does not exist
+	 * @throws ElementNotAFileException
+	 *             if the SubmodelElement is not a File
+	 * @throws FileDoesNotExistException
+	 *             if the referenced file content does not exist
+	 */
+	public InputStream getFileAsStream(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		SubmodelElement submodelElement = submodelOperations.getSubmodelElement(submodelId, idShortPath);
+
+		throwIfSmElementIsNotAFile(submodelElement);
+
+		File fileSmElement = (File) submodelElement;
+		String filePath = getFilePath(fileSmElement);
+
+		return FileRepositoryHelper.getFileInputStream(fileRepository, filePath);
+	}
+
+	/**
+	 * Stores new content for a file submodel element and updates the element value
+	 * with the generated repository id.
+	 *
+	 * @param submodelId
+	 *            the id of the Submodel
+	 * @param idShortPath
+	 *            the idShort path of the file element
+	 * @param fileName
+	 *            the logical display name of the uploaded file
+	 * @param contentType
+	 *            the file MIME type
+	 * @param inputStream
+	 *            the file content stream
+	 * @throws ElementDoesNotExistException
+	 *             if the SubmodelElement does not exist
+	 * @throws ElementNotAFileException
+	 *             if the SubmodelElement is not a File
+	 */
 	public void setFileValue(String submodelId, String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
         SubmodelElement submodelElement = submodelOperations.getSubmodelElement(submodelId, idShortPath);
 
         throwIfSmElementIsNotAFile(submodelElement);
 
         File fileSmElement = (File) submodelElement;
+        String oldFilePath = fileSmElement.getValue();
 
-        if (fileRepository.exists(fileSmElement.getValue()))
-            fileRepository.delete(fileSmElement.getValue());
-
-		String logicalFileName = validateLogicalFileName(fileName);
-		String uniqueFileName = createUniqueFileName(logicalFileName);
-
-		FileMetadata fileMetadata = new FileMetadata(uniqueFileName, logicalFileName, contentType, inputStream);
-
-        if (fileRepository.exists(fileMetadata.getFileName()))
-            fileRepository.delete(fileMetadata.getFileName());
-
-        String filePath = fileRepository.save(fileMetadata);
-
-        FileBlobValue fileValue = new FileBlobValue(contentType, filePath);
-
-        submodelOperations.setSubmodelElementValue(submodelId, idShortPath, fileValue);
+        FileRepositoryHelper.saveAndUpdateReference(fileRepository, oldFilePath, fileName, contentType, inputStream, filePath -> submodelOperations.setSubmodelElementValue(submodelId, idShortPath, new FileBlobValue(contentType, filePath)));
 	}
 
+	/**
+	 * Clears a file submodel element value and deletes the referenced repository
+	 * content.
+	 *
+	 * @param submodelId
+	 *            the id of the Submodel
+	 * @param idShortPath
+	 *            the idShort path of the file element
+	 * @throws ElementDoesNotExistException
+	 *             if the SubmodelElement does not exist
+	 * @throws ElementNotAFileException
+	 *             if the SubmodelElement is not a File
+	 * @throws FileDoesNotExistException
+	 *             if the referenced file content does not exist
+	 */
 	public void deleteFileValue(String submodelId, String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
         SubmodelElement submodelElement = submodelOperations.getSubmodelElement(submodelId, idShortPath);
 
@@ -101,17 +162,32 @@ public class SubmodelFileOperations  {
         File fileSubmodelElement = (File) submodelElement;
         String filePath = fileSubmodelElement.getValue();
 
-        fileRepository.delete(filePath);
-
-        FileBlobValue fileValue = new FileBlobValue(" ", " ");
-
-        submodelOperations.setSubmodelElementValue(submodelId, idShortPath, fileValue);
+		FileRepositoryHelper.updateReferenceAndDeleteFile(fileRepository, filePath, () -> submodelOperations.setSubmodelElementValue(submodelId, idShortPath, new FileBlobValue(" ", " ")));
     }
 
-	public InputStream getInputStream(String filePath) throws FileDoesNotExistException{
-		return fileRepository.find(filePath);
+	/**
+	 * Retrieves repository content by repository storage id.
+	 * <p>
+	 * Prefer {@link #getFileAsStream(String, String)} for domain-level file
+	 * downloads. The caller is responsible for closing the returned stream.
+	 *
+	 * @param filePath
+	 *            the repository file id
+	 * @return the repository content stream
+	 * @throws FileDoesNotExistException
+	 *             if the repository file id does not exist
+	 */
+	public InputStream getInputStream(String filePath) throws FileDoesNotExistException {
+		return FileRepositoryHelper.getFileInputStream(fileRepository, filePath);
 	}
 
+	/**
+	 * Resolves the original logical filename for a repository file id.
+	 *
+	 * @param filePath
+	 *            the repository file id
+	 * @return the original logical filename
+	 */
 	public String getOriginalFileName(String filePath) {
 		return fileRepository.getOriginalFileName(filePath);
 	}
@@ -120,74 +196,14 @@ public class SubmodelFileOperations  {
 		return submodelElement instanceof File;
 	}
 
-	private InputStream getFileInputStream(String filePath) {
-		InputStream fileContent;
-
-		try {
-			fileContent = fileRepository.find(filePath);
-		} catch (FileDoesNotExistException e) {
-			throw new FileDoesNotExistException(String.format("File at path '%s' could not be found.", filePath));
-		}
-
-		return fileContent;
-	}
-
-	private static java.io.File createFile(String filePath, InputStream fileIs) {
-
-		try {
-			byte[] content = fileIs.readAllBytes();
-			fileIs.close();
-
-			createOutputStream(filePath, content);
-
-			return new java.io.File(filePath);
-		} catch (IOException e) {
-			throw new FileHandlingException("Exception occurred while creating file from the InputStream." + e.getMessage());
-		}
-
-	}
-
 	private static String getFilePath(File fileSubmodelElement) {
 		return fileSubmodelElement.getValue();
-	}
-
-	private static String createUniqueFileName(String logicalFileName) {
-		return UUID.randomUUID() + getFileExtension(logicalFileName);
-	}
-
-	private static String getFileExtension(String fileName) {
-		int extensionStart = fileName.lastIndexOf('.');
-
-		if (extensionStart <= 0 || extensionStart >= fileName.length() - 1)
-			return "";
-
-		return fileName.substring(extensionStart);
-	}
-
-	private static String validateLogicalFileName(String fileName) {
-		if (fileName == null || fileName.isBlank())
-			throw new IllegalArgumentException("File name must not be null or blank.");
-
-		if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\"))
-			throw new SecurityException("Path traversal attempt detected.");
-
-		return fileName.replace("\r", "_").replace("\n", "_").trim();
 	}
 
 	private static void throwIfSmElementIsNotAFile(SubmodelElement submodelElement) {
 
 		if (!isFileSubmodelElement(submodelElement))
 			throw new ElementNotAFileException(submodelElement.getIdShort());
-	}
-
-    private static void createOutputStream(String filePath, byte[] content) throws IOException {
-
-		try (OutputStream outputStream = new FileOutputStream(filePath)) {
-			outputStream.write(content);
-		} catch (IOException e) {
-			throw new FileHandlingException("Exception occurred while creating OutputStream from byte[]." + e.getMessage());
-		}
-
 	}
 
 }

--- a/basyx.submodelservice/basyx.submodelservice-backend/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/CrudSubmodelServiceFileHandlingTest.java
+++ b/basyx.submodelservice/basyx.submodelservice-backend/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/backend/CrudSubmodelServiceFileHandlingTest.java
@@ -1,0 +1,265 @@
+/*******************************************************************************
+ * Copyright (C) 2026 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.submodelservice.backend;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultFile;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
+import org.eclipse.digitaltwin.basyx.core.filerepository.FileMetadata;
+import org.eclipse.digitaltwin.basyx.core.filerepository.FileRepository;
+import org.junit.Test;
+
+public class CrudSubmodelServiceFileHandlingTest {
+
+	private static final String SUBMODEL_ID = "submodel-1";
+	private static final String FILE_ID_SHORT = "document";
+
+	@Test
+	public void getFileByPathWithAbsoluteStoredPathWritesOnlyTempFile() throws IOException {
+		Path victimDirectory = Files.createTempDirectory("basyx-victim");
+		Path victimFile = victimDirectory.resolve("pwned.txt");
+		String maliciousRepositoryKey = victimFile.toAbsolutePath().toString();
+		byte[] attackerPayload = "attacker bytes".getBytes(UTF_8);
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(maliciousRepositoryKey, attackerPayload);
+		TestSubmodelBackend backend = new TestSubmodelBackend(fileElement(maliciousRepositoryKey));
+		CrudSubmodelService service = new CrudSubmodelService(backend.proxy(), fileRepository, SUBMODEL_ID);
+
+		try {
+			java.io.File localFile = service.getFileByPath(FILE_ID_SHORT);
+
+			assertTrue(localFile.exists());
+			assertNotEquals(victimFile.toAbsolutePath().toString(), localFile.toPath().toAbsolutePath().toString());
+			assertFalse(Files.exists(victimFile));
+			assertArrayEquals(attackerPayload, Files.readAllBytes(localFile.toPath()));
+			Files.deleteIfExists(localFile.toPath());
+		} finally {
+			Files.deleteIfExists(victimFile);
+			Files.deleteIfExists(victimDirectory);
+		}
+	}
+
+	@Test
+	public void getFileByPathAsStreamWithAbsoluteStoredPathDoesNotWriteToDisk() throws IOException {
+		Path victimDirectory = Files.createTempDirectory("basyx-victim");
+		Path victimFile = victimDirectory.resolve("pwned.txt");
+		String maliciousRepositoryKey = victimFile.toAbsolutePath().toString();
+		byte[] attackerPayload = "attacker bytes".getBytes(UTF_8);
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(maliciousRepositoryKey, attackerPayload);
+		TestSubmodelBackend backend = new TestSubmodelBackend(fileElement(maliciousRepositoryKey));
+		CrudSubmodelService service = new CrudSubmodelService(backend.proxy(), fileRepository, SUBMODEL_ID);
+
+		try (InputStream inputStream = service.getFileByPathAsStream(FILE_ID_SHORT)) {
+			assertArrayEquals(attackerPayload, inputStream.readAllBytes());
+			assertFalse(Files.exists(victimFile));
+		} finally {
+			Files.deleteIfExists(victimFile);
+			Files.deleteIfExists(victimDirectory);
+		}
+	}
+
+	@Test
+	public void updateFileElementWithUnchangedPathDoesNotMaterializeExistingFile() throws IOException {
+		Path victimDirectory = Files.createTempDirectory("basyx-victim");
+		Path victimFile = victimDirectory.resolve("pwned.txt");
+		String maliciousRepositoryKey = victimFile.toAbsolutePath().toString();
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(maliciousRepositoryKey, "attacker bytes".getBytes(UTF_8));
+		TestSubmodelBackend backend = new TestSubmodelBackend(fileElement(maliciousRepositoryKey));
+		CrudSubmodelService service = new CrudSubmodelService(backend.proxy(), fileRepository, SUBMODEL_ID);
+
+		try {
+			service.updateSubmodelElement(FILE_ID_SHORT, fileElement(maliciousRepositoryKey));
+
+			assertEquals(0, fileRepository.findCalls);
+			assertEquals(1, backend.updateCalls);
+			assertFalse(Files.exists(victimFile));
+		} finally {
+			Files.deleteIfExists(victimFile);
+			Files.deleteIfExists(victimDirectory);
+		}
+	}
+
+	@Test
+	public void setFileValueCleansNewFileAndKeepsOldFileWhenValueUpdateFails() {
+		String oldFilePath = "old-file";
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(oldFilePath, "old".getBytes(UTF_8));
+		TestSubmodelBackend backend = new TestSubmodelBackend(fileElement(oldFilePath));
+		backend.failSetSubmodelElementValue = true;
+		CrudSubmodelService service = new CrudSubmodelService(backend.proxy(), fileRepository, SUBMODEL_ID);
+
+		try {
+			service.setFileValue(FILE_ID_SHORT, "new.txt", "text/plain", new ByteArrayInputStream("new".getBytes(UTF_8)));
+		} catch (RuntimeException e) {
+			assertTrue(fileRepository.exists(oldFilePath));
+			assertEquals(1, fileRepository.size());
+			return;
+		}
+
+		throw new AssertionError("Expected setFileValue to fail.");
+	}
+
+	@Test
+	public void deleteFileValueKeepsFileWhenValueUpdateFails() {
+		String oldFilePath = "old-file";
+		GridFsLikeFileRepository fileRepository = new GridFsLikeFileRepository();
+		fileRepository.put(oldFilePath, "old".getBytes(UTF_8));
+		TestSubmodelBackend backend = new TestSubmodelBackend(fileElement(oldFilePath));
+		backend.failSetSubmodelElementValue = true;
+		CrudSubmodelService service = new CrudSubmodelService(backend.proxy(), fileRepository, SUBMODEL_ID);
+
+		assertThrows(RuntimeException.class, () -> service.deleteFileValue(FILE_ID_SHORT));
+
+		assertTrue(fileRepository.exists(oldFilePath));
+		assertEquals(1, fileRepository.size());
+	}
+
+	private static org.eclipse.digitaltwin.aas4j.v3.model.File fileElement(String value) {
+		return new DefaultFile.Builder().idShort(FILE_ID_SHORT).contentType("text/plain").value(value).build();
+	}
+
+	private static class TestSubmodelBackend implements InvocationHandler {
+		private final AtomicReference<SubmodelElement> submodelElement;
+		private int updateCalls;
+		private boolean failSetSubmodelElementValue;
+
+		TestSubmodelBackend(SubmodelElement submodelElement) {
+			this.submodelElement = new AtomicReference<>(submodelElement);
+		}
+
+		SubmodelBackend proxy() {
+			return (SubmodelBackend) Proxy.newProxyInstance(SubmodelBackend.class.getClassLoader(), new Class<?>[] { SubmodelBackend.class }, this);
+		}
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) {
+			if (method.getDeclaringClass() == Object.class)
+				return invokeObjectMethod(proxy, method, args);
+
+			switch (method.getName()) {
+				case "getSubmodelElement":
+					return submodelElement.get();
+				case "updateSubmodelElement":
+					submodelElement.set((SubmodelElement) args[2]);
+					updateCalls++;
+					return null;
+				case "setSubmodelElementValue":
+					if (failSetSubmodelElementValue)
+						throw new RuntimeException("Could not update submodel element value.");
+
+					return null;
+				default:
+					throw new UnsupportedOperationException(method.getName());
+			}
+		}
+
+		private Object invokeObjectMethod(Object proxy, Method method, Object[] args) {
+			switch (method.getName()) {
+				case "equals":
+					return proxy == args[0];
+				case "hashCode":
+					return System.identityHashCode(proxy);
+				case "toString":
+					return "TestSubmodelBackend";
+				default:
+					throw new UnsupportedOperationException(method.getName());
+			}
+		}
+	}
+
+	private static class GridFsLikeFileRepository implements FileRepository {
+		private final Map<String, byte[]> store = new HashMap<>();
+		private int findCalls;
+
+		@Override
+		public String save(FileMetadata metadata) throws FileHandlingException {
+			if (exists(metadata.getFileName()))
+				throw new FileHandlingException("File '%s' already exists.".formatted(metadata.getFileName()));
+
+			try {
+				store.put(metadata.getFileName(), metadata.getFileContent().readAllBytes());
+			} catch (IOException e) {
+				throw new FileHandlingException(metadata.getFileName(), e);
+			}
+
+			return metadata.getFileName();
+		}
+
+		@Override
+		public InputStream find(String fileId) throws FileDoesNotExistException {
+			findCalls++;
+
+			if (!exists(fileId))
+				throw new FileDoesNotExistException();
+
+			return new ByteArrayInputStream(store.get(fileId));
+		}
+
+		@Override
+		public void delete(String fileId) throws FileDoesNotExistException {
+			if (!exists(fileId))
+				throw new FileDoesNotExistException();
+
+			store.remove(fileId);
+		}
+
+		@Override
+		public boolean exists(String fileId) {
+			return fileId != null && store.containsKey(fileId);
+		}
+
+		void put(String fileId, byte[] content) {
+			store.put(fileId, content);
+		}
+
+		int size() {
+			return store.size();
+		}
+	}
+}

--- a/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/ConnectedSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-client/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/client/ConnectedSubmodelService.java
@@ -27,7 +27,10 @@
 package org.eclipse.digitaltwin.basyx.submodelservice.client;
 
 import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -177,6 +180,11 @@ public class ConnectedSubmodelService implements SubmodelService {
 	}
 
 	@Override
+	public InputStream getFileByPathAsStream(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return openFileAndDeleteOnClose(getFileByPath(idShortPath));
+	}
+
+	@Override
 	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		try {
 			serviceApi.putFileByPath(idShortPath, fileName, contentType, inputStream);
@@ -206,6 +214,23 @@ public class ConnectedSubmodelService implements SubmodelService {
 	@Override
 	public InputStream getFileByFilePath(String filePath) {
 		throw new NotImplementedException("This Method is not implemented in the Client");
+	}
+
+	private static InputStream openFileAndDeleteOnClose(File file) {
+		try {
+			return new FilterInputStream(Files.newInputStream(file.toPath())) {
+				@Override
+				public void close() throws IOException {
+					try {
+						super.close();
+					} finally {
+						Files.deleteIfExists(file.toPath());
+					}
+				}
+			};
+		} catch (IOException e) {
+			throw new FileHandlingException("Could not open file stream.", e);
+		}
 	}
 
 	private RuntimeException mapExceptionFileAccess(String idShortPath, ApiException e) {

--- a/basyx.submodelservice/basyx.submodelservice-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-core/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/SubmodelService.java
@@ -25,6 +25,8 @@
 
 package org.eclipse.digitaltwin.basyx.submodelservice;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -34,6 +36,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementNotAFileException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.FileDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.FileHandlingException;
 import org.eclipse.digitaltwin.basyx.core.pagination.CursorResult;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelElementValue;
@@ -147,7 +150,10 @@ public interface SubmodelService {
 	public OperationVariable[] invokeOperation(String idShortPath, OperationVariable[] input) throws ElementDoesNotExistException;
 
 	/**
-	 * Retrieves the file of a file submodelelement
+	 * Retrieves the file of a file submodelelement.
+	 * <p>
+	 * Implementations that materialize repository content as a temporary file must
+	 * document whether the caller is responsible for deleting the returned file.
 	 * 
 	 * @param idShortPath
 	 *            the IdShort path of the file element
@@ -157,6 +163,31 @@ public interface SubmodelService {
 	 * @throws FileDoesNotExistException
 	 */
 	public java.io.File getFileByPath(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException;
+
+	/**
+	 * Retrieves the content of a file submodel element as a stream.
+	 * <p>
+	 * The file is resolved by the submodel element idShort path, not by the
+	 * repository storage id. The caller is responsible for closing the returned
+	 * stream.
+	 *
+	 * @param idShortPath
+	 *            the IdShort path of the file element
+	 * @return File InputStream
+	 * @throws ElementDoesNotExistException
+	 *             if the SubmodelElement does not exist
+	 * @throws ElementNotAFileException
+	 *             if the SubmodelElement is not a File
+	 * @throws FileDoesNotExistException
+	 *             if the referenced file content does not exist
+	 */
+	public default InputStream getFileByPathAsStream(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		try {
+			return new FileInputStream(getFileByPath(idShortPath));
+		} catch (FileNotFoundException e) {
+			throw new FileHandlingException("Could not open file stream.", e);
+		}
+	}
 
 	/**
 	 * Uploads a file to a file submodelelement
@@ -189,11 +220,13 @@ public interface SubmodelService {
 
 
 	/**
-	 * Retrieves the file of a file submodelelement via its absolute path
+	 * Retrieves file content by repository storage id.
 	 *
 	 * @param filePath
-	 *            the path of the file
+	 *            the repository file id
 	 * @return File InputStream
+	 * @throws FileDoesNotExistException
+	 *             if the repository file id does not exist
 	 */
 	public InputStream getFileByFilePath(String filePath);
 

--- a/basyx.submodelservice/basyx.submodelservice-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/authorization/AuthorizedSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-authorization/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/authorization/AuthorizedSubmodelService.java
@@ -87,6 +87,13 @@ public class AuthorizedSubmodelService implements SubmodelService {
 	}
 
 	@Override
+	public InputStream getFileByPathAsStream(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new SubmodelTargetInformation(List.of(smId), List.of(idShortPath)));
+		throwExceptionIfInsufficientPermission(isAuthorized);
+		return decorated.getFileByPathAsStream(idShortPath);
+	}
+
+	@Override
 	public SubmodelElement getSubmodelElement(String idShortPath) throws ElementDoesNotExistException {
 		boolean isAuthorized = permissionResolver.hasPermission(Action.READ, new SubmodelTargetInformation(List.of(smId), List.of(idShortPath)));
 		throwExceptionIfInsufficientPermission(isAuthorized);

--- a/basyx.submodelservice/basyx.submodelservice-feature-authorization/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/authorization/AuthorizedSubmodelServiceFileStreamTest.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-authorization/src/test/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/authorization/AuthorizedSubmodelServiceFileStreamTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (C) 2026 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.submodelservice.feature.authorization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+
+import org.eclipse.digitaltwin.basyx.authorization.rbac.Action;
+import org.eclipse.digitaltwin.basyx.authorization.rbac.RbacPermissionResolver;
+import org.eclipse.digitaltwin.basyx.core.exceptions.InsufficientPermissionException;
+import org.eclipse.digitaltwin.basyx.submodelservice.SubmodelService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AuthorizedSubmodelServiceFileStreamTest {
+
+	private static final String SUBMODEL_ID = "smId";
+	private static final String FILE_ID_SHORT_PATH = "document";
+	private static final String REPOSITORY_FILE_ID = "file-repository-id";
+	private static final byte[] FILE_CONTENT = "content".getBytes();
+
+	@Test
+	void getFileByPathAsStreamAuthorizesByFileIdShortPath() throws Exception {
+		SubmodelService decorated = mock(SubmodelService.class);
+		when(decorated.getFileByPathAsStream(FILE_ID_SHORT_PATH)).thenReturn(new ByteArrayInputStream(FILE_CONTENT));
+		RbacPermissionResolver<SubmodelTargetInformation> permissionResolver = permissionResolverAllowing(FILE_ID_SHORT_PATH);
+
+		AuthorizedSubmodelService service = new AuthorizedSubmodelService(decorated, permissionResolver, SUBMODEL_ID);
+
+		try (InputStream result = service.getFileByPathAsStream(FILE_ID_SHORT_PATH)) {
+			assertArrayEquals(FILE_CONTENT, result.readAllBytes());
+		}
+
+		ArgumentCaptor<SubmodelTargetInformation> targetInformation = ArgumentCaptor.forClass(SubmodelTargetInformation.class);
+		verify(permissionResolver).hasPermission(eq(Action.READ), targetInformation.capture());
+		assertEquals(List.of(SUBMODEL_ID), targetInformation.getValue().getSubmodelIds());
+		assertEquals(List.of(FILE_ID_SHORT_PATH), targetInformation.getValue().getSubmodelElementIdShortPaths());
+		verify(decorated).getFileByPathAsStream(FILE_ID_SHORT_PATH);
+		verify(decorated, never()).getFileByFilePath(anyString());
+	}
+
+	@Test
+	void getFileByPathAsStreamDoesNotAuthorizeByRepositoryFileId() throws Exception {
+		SubmodelService decorated = mock(SubmodelService.class);
+		RbacPermissionResolver<SubmodelTargetInformation> permissionResolver = permissionResolverAllowing(REPOSITORY_FILE_ID);
+
+		AuthorizedSubmodelService service = new AuthorizedSubmodelService(decorated, permissionResolver, SUBMODEL_ID);
+
+		assertThrows(InsufficientPermissionException.class, () -> service.getFileByPathAsStream(FILE_ID_SHORT_PATH));
+		verify(decorated, never()).getFileByPathAsStream(anyString());
+		verify(decorated, never()).getFileByFilePath(anyString());
+	}
+
+	private static RbacPermissionResolver<SubmodelTargetInformation> permissionResolverAllowing(String allowedIdShortPath) {
+		@SuppressWarnings("unchecked")
+		RbacPermissionResolver<SubmodelTargetInformation> permissionResolver = mock(RbacPermissionResolver.class);
+		when(permissionResolver.hasPermission(eq(Action.READ), any(SubmodelTargetInformation.class))).thenAnswer(invocation -> {
+			SubmodelTargetInformation targetInformation = invocation.getArgument(1);
+			return List.of(SUBMODEL_ID).equals(targetInformation.getSubmodelIds()) && List.of(allowedIdShortPath).equals(targetInformation.getSubmodelElementIdShortPaths());
+		});
+		return permissionResolver;
+	}
+
+}

--- a/basyx.submodelservice/basyx.submodelservice-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/kafka/KafkaSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-kafka/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/kafka/KafkaSubmodelService.java
@@ -130,6 +130,12 @@ public class KafkaSubmodelService implements SubmodelService {
 	}
 
 	@Override
+	public InputStream getFileByPathAsStream(String idShortPath)
+			throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return decorated.getFileByPathAsStream(idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream)
 			throws ElementDoesNotExistException, ElementNotAFileException {
 		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);

--- a/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/mqtt/MqttSubmodelService.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-mqtt/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/mqtt/MqttSubmodelService.java
@@ -140,6 +140,11 @@ public class MqttSubmodelService implements SubmodelService {
 	}
 
 	@Override
+	public InputStream getFileByPathAsStream(String idShortPath) throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return decorated.getFileByPathAsStream(idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream) throws ElementDoesNotExistException, ElementNotAFileException {
 		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);
 	}

--- a/basyx.submodelservice/basyx.submodelservice-feature-operation-dispatching/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/operationdispatching/AbstractSubmodelServiceDecorator.java
+++ b/basyx.submodelservice/basyx.submodelservice-feature-operation-dispatching/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/feature/operationdispatching/AbstractSubmodelServiceDecorator.java
@@ -116,6 +116,12 @@ public class AbstractSubmodelServiceDecorator implements SubmodelService {
 	}
 
 	@Override
+	public InputStream getFileByPathAsStream(String idShortPath)
+			throws ElementDoesNotExistException, ElementNotAFileException, FileDoesNotExistException {
+		return decorated.getFileByPathAsStream(idShortPath);
+	}
+
+	@Override
 	public void setFileValue(String idShortPath, String fileName, String contentType, InputStream inputStream)
 			throws ElementDoesNotExistException, ElementNotAFileException {
 		decorated.setFileValue(idShortPath, fileName, contentType, inputStream);

--- a/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
+++ b/basyx.submodelservice/basyx.submodelservice-http/src/main/java/org/eclipse/digitaltwin/basyx/submodelservice/http/SubmodelServiceHTTPApiController.java
@@ -52,7 +52,7 @@ import org.eclipse.digitaltwin.basyx.submodelservice.SubmodelService;
 import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelElementValue;
 import org.eclipse.digitaltwin.basyx.submodelservice.value.SubmodelValueOnly;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -259,8 +259,12 @@ public class SubmodelServiceHTTPApiController implements SubmodelServiceHTTPApi 
 
 	@Override
 	public ResponseEntity<Resource> getFileByPath(String idShortPath) {
-		Resource resource = new FileSystemResource(service.getFileByPath(idShortPath));
-		org.eclipse.digitaltwin.aas4j.v3.model.File fileSubmodelElement = (org.eclipse.digitaltwin.aas4j.v3.model.File) service.getSubmodelElement(idShortPath);
+		SubmodelElement submodelElement = service.getSubmodelElement(idShortPath);
+
+		if (!(submodelElement instanceof org.eclipse.digitaltwin.aas4j.v3.model.File fileSubmodelElement))
+			throw new ElementNotAFileException(submodelElement.getIdShort());
+
+		Resource resource = new InputStreamResource(service.getFileByPathAsStream(idShortPath));
 
 		return ResponseEntity.ok()
 				.contentType(BaSyxMediaType.parseOrOctetStream(fileSubmodelElement.getContentType()))


### PR DESCRIPTION
## Summary

This PR fixes unsafe repository file handling for thumbnails, submodel attachments, and AASX packages.

Uploaded filenames are no longer used as repository ids or filesystem paths. They are treated as logical display names only, validated centrally, and stored as metadata while repository storage uses generated ids.

## Changes

- Added shared file lifecycle helpers in `FileRepositoryHelper`
  - validates uploaded logical filenames
  - rejects traversal/path-like names
  - stores files under generated ids
  - preserves original filenames as metadata
  - centralizes save/update/delete behavior
  - provides safe stream and temp-file retrieval paths

- Updated AAS thumbnail handling
  - stream downloads via repository `InputStream`
  - safe temp-file fallback for legacy `File` API
  - delete old thumbnail content after successful replacement
  - handle missing/cleared thumbnails as `FileDoesNotExistException`

- Updated submodel attachment handling
  - stream HTTP downloads by `idShortPath`
  - avoid materializing previous files just to compare values
  - authorize streamed downloads by submodel element path, not repository id

- Updated AASX package handling
  - use the same shared helper as thumbnails and attachments
  - reject traversal filenames on create/update
  - update package metadata before deleting old repository content

- Preserved Java API compatibility
  - new stream methods are default methods on public interfaces
  - server implementations override them with direct streaming behavior

## Tests

- Added regression tests for malicious filenames and safe repository ids
- Added thumbnail and submodel streaming/path traversal coverage
- Added authorization coverage for attachment stream access
- Added AASX create/update filename validation coverage