### PR TITLE
Fix AAS registry descriptor synchronization

### DIFF
--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/Readme.md
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/Readme.md
@@ -1,6 +1,6 @@
 # AssetAdministrationShell Repository - Registry Integration
-This feature automatically integrates the Descriptor with the Registry while creation of the Shell at Repository. <br>
-It also automatically removes the Descriptor from the Registry when the Shell is removed from the Repository. 
+This feature automatically creates and updates the Descriptor in the Registry when a Shell or its Asset Information changes in the Repository. <br>
+It also automatically removes the Descriptor from the Registry when the Shell is removed from the Repository.
 
 To enable this feature, the following two properties should be configured:
 
@@ -32,3 +32,13 @@ basyx.aasrepository.feature.registryintegration.authorization.username=test
 basyx.aasrepository.feature.registryintegration.authorization.password=test
 basyx.aasrepository.feature.registryintegration.authorization.scopes=[]
 ```
+
+The Registry permissions required by the integration are:
+
+- `CREATE` when a Shell is created
+- `READ` and `UPDATE` when a Shell or its Asset Information is updated
+- `DELETE` when a Shell is deleted
+
+`READ` is required during updates because the Registry API replaces complete descriptors. The integration reads the existing descriptor first so that Registry-managed endpoint metadata and Submodel Descriptors are retained.
+
+The Registry API currently provides neither conditional updates nor a partial update operation for Shell Descriptors. Consequently, descriptor changes made directly in the Registry by another client must not run concurrently with an AAS update if both changes need to be retained.

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
@@ -26,7 +26,9 @@ package org.eclipse.digitaltwin.basyx.aasrepository.feature.registry.integration
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
@@ -54,17 +56,20 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class RegistryIntegrationAasRepository implements AasRepository {
+	private static final int SHELL_LOCK_COUNT = 64;
 	private static Logger logger = LoggerFactory.getLogger(RegistryIntegrationAasRepository.class);
 
 	private AasRepository decorated;
 	
 	private AasRepositoryRegistryLink aasRepositoryRegistryLink;
 	private AttributeMapper attributeMapper;
+	private final Object[] shellMutationLocks = new Object[SHELL_LOCK_COUNT];
 
 	public RegistryIntegrationAasRepository(AasRepository decorated, AasRepositoryRegistryLink aasRepositoryRegistryLink, AttributeMapper attributeMapper) {
 		this.decorated = decorated;
 		this.aasRepositoryRegistryLink = aasRepositoryRegistryLink;
 		this.attributeMapper = attributeMapper;
+		Arrays.setAll(shellMutationLocks, index -> new Object());
 	}
 
 	@Override
@@ -79,40 +84,45 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	@Override
 	public void createAas(AssetAdministrationShell shell) throws CollidingIdentifierException {
-		AssetAdministrationShellDescriptor descriptor = createDescriptor(shell);
+		synchronized (getShellMutationLock(shell.getId())) {
+			AssetAdministrationShellDescriptor descriptor = createDescriptor(shell);
 
-		decorated.createAas(shell);
+			decorated.createAas(shell);
 
-		boolean registrationSuccessful = false;
+			boolean registrationSuccessful = false;
 
-		try {
-			registerAas(descriptor);
-			registrationSuccessful = true;
-		} finally {
-			if (!registrationSuccessful)
-				decorated.deleteAas(shell.getId());
+			try {
+				registerAas(descriptor);
+				registrationSuccessful = true;
+			} finally {
+				if (!registrationSuccessful)
+					decorated.deleteAas(shell.getId());
+			}
 		}
 	}
 
 	@Override
 	public void updateAas(String shellId, AssetAdministrationShell shell) {
-		AssetAdministrationShell previousShell = decorated.getAas(shellId);
+		synchronized (getShellMutationLock(shellId)) {
+			AssetAdministrationShell previousShell = decorated.getAas(shellId);
 
-		decorated.updateAas(shellId, shell);
+			decorated.updateAas(shellId, shell);
 
-		try {
-			updateDescriptor(shellId, shell);
-		} catch (RuntimeException e) {
-			rollbackAasUpdate(shellId, previousShell, e);
-			throw e;
+			try {
+				updateDescriptor(shellId, shell);
+			} catch (RuntimeException e) {
+				rollbackAasUpdate(shellId, previousShell, e);
+				throw e;
+			}
 		}
 	}
 
 	@Override
 	public void deleteAas(String shellId) {
-		deleteFromRegistry(shellId);
-		
-		decorated.deleteAas(shellId);
+		synchronized (getShellMutationLock(shellId)) {
+			deleteFromRegistry(shellId);
+			decorated.deleteAas(shellId);
+		}
 	}
 
 	@Override
@@ -127,25 +137,31 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	@Override
 	public void addSubmodelReference(String shellId, Reference submodelReference) {
-		decorated.addSubmodelReference(shellId, submodelReference);
+		synchronized (getShellMutationLock(shellId)) {
+			decorated.addSubmodelReference(shellId, submodelReference);
+		}
 	}
 
 	@Override
 	public void removeSubmodelReference(String shellId, String submodelId) {
-		decorated.removeSubmodelReference(shellId, submodelId);
+		synchronized (getShellMutationLock(shellId)) {
+			decorated.removeSubmodelReference(shellId, submodelId);
+		}
 	}
 
 	@Override
 	public void setAssetInformation(String shellId, AssetInformation shellInfo) throws ElementDoesNotExistException {
-		AssetInformation previousAssetInformation = decorated.getAssetInformation(shellId);
+		synchronized (getShellMutationLock(shellId)) {
+			AssetInformation previousAssetInformation = decorated.getAssetInformation(shellId);
 
-		decorated.setAssetInformation(shellId, shellInfo);
+			decorated.setAssetInformation(shellId, shellInfo);
 
-		try {
-			updateDescriptor(shellId, decorated.getAas(shellId));
-		} catch (RuntimeException e) {
-			rollbackAssetInformationUpdate(shellId, previousAssetInformation, e);
-			throw e;
+			try {
+				updateDescriptor(shellId, decorated.getAas(shellId));
+			} catch (RuntimeException e) {
+				rollbackAssetInformationUpdate(shellId, previousAssetInformation, e);
+				throw e;
+			}
 		}
 	}
 
@@ -168,18 +184,60 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	private void updateDescriptor(String shellId, AssetAdministrationShell shell) {
 		RegistryAndDiscoveryInterfaceApi registryApi = aasRepositoryRegistryLink.getRegistryApi();
+		AssetAdministrationShellDescriptor existingDescriptor;
 
 		try {
-			AssetAdministrationShellDescriptor existingDescriptor = registryApi.getAssetAdministrationShellDescriptorById(shellId);
-			AssetAdministrationShellDescriptor updatedDescriptor = createDescriptor(shell);
-			updatedDescriptor.setSubmodelDescriptors(existingDescriptor.getSubmodelDescriptors());
+			existingDescriptor = registryApi.getAssetAdministrationShellDescriptorById(shellId);
+		} catch (ApiException e) {
+			throw createRegistryLinkException(shellId, "update", e);
+		}
 
+		AssetAdministrationShellDescriptor updatedDescriptor = createDescriptor(shell);
+		preserveRegistryManagedAttributes(existingDescriptor, updatedDescriptor);
+
+		try {
 			registryApi.putAssetAdministrationShellDescriptorById(shellId, updatedDescriptor);
 
 			logger.info("Shell descriptor '{}' has been automatically updated in the Registry", shellId);
 		} catch (ApiException e) {
+			if (descriptorMatchesAasDerivedState(shellId, updatedDescriptor, registryApi, e)) {
+				logger.warn("Registry update for shell descriptor '{}' returned an error, but a read-back confirmed the requested AAS-derived state.", shellId);
+				return;
+			}
+
 			throw createRegistryLinkException(shellId, "update", e);
 		}
+	}
+
+	private void preserveRegistryManagedAttributes(AssetAdministrationShellDescriptor existingDescriptor, AssetAdministrationShellDescriptor updatedDescriptor) {
+		if (existingDescriptor.getEndpoints() != null)
+			updatedDescriptor.setEndpoints(existingDescriptor.getEndpoints());
+
+		updatedDescriptor.setSubmodelDescriptors(existingDescriptor.getSubmodelDescriptors());
+	}
+
+	private boolean descriptorMatchesAasDerivedState(String shellId, AssetAdministrationShellDescriptor expectedDescriptor, RegistryAndDiscoveryInterfaceApi registryApi, ApiException updateException) {
+		try {
+			AssetAdministrationShellDescriptor actualDescriptor = registryApi.getAssetAdministrationShellDescriptorById(shellId);
+			return aasDerivedAttributesEqual(expectedDescriptor, actualDescriptor);
+		} catch (ApiException verificationException) {
+			updateException.addSuppressed(verificationException);
+			return false;
+		}
+	}
+
+	private boolean aasDerivedAttributesEqual(AssetAdministrationShellDescriptor expected, AssetAdministrationShellDescriptor actual) {
+		return actual != null
+				&& Objects.equals(expected.getAdministration(), actual.getAdministration())
+				&& Objects.equals(expected.getAssetKind(), actual.getAssetKind())
+				&& Objects.equals(expected.getAssetType(), actual.getAssetType())
+				&& Objects.equals(expected.getDescription(), actual.getDescription())
+				&& Objects.equals(expected.getDisplayName(), actual.getDisplayName())
+				&& Objects.equals(expected.getExtensions(), actual.getExtensions())
+				&& Objects.equals(expected.getGlobalAssetId(), actual.getGlobalAssetId())
+				&& Objects.equals(expected.getId(), actual.getId())
+				&& Objects.equals(expected.getIdShort(), actual.getIdShort())
+				&& Objects.equals(expected.getSpecificAssetIds(), actual.getSpecificAssetIds());
 	}
 
 	private AssetAdministrationShellDescriptor createDescriptor(AssetAdministrationShell shell) {
@@ -187,6 +245,14 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 	}
 
 	private RepositoryRegistryLinkException createRegistryLinkException(String shellId, String operation, ApiException cause) {
+		return new RepositoryRegistryLinkException(shellId, createRegistryFailureDetails(operation, cause), cause);
+	}
+
+	private RepositoryRegistryUnlinkException createRegistryUnlinkException(String shellId, ApiException cause) {
+		return new RepositoryRegistryUnlinkException(shellId, createRegistryFailureDetails("deletion", cause), cause);
+	}
+
+	private String createRegistryFailureDetails(String operation, ApiException cause) {
 		StringBuilder details = new StringBuilder("Registry descriptor ").append(operation).append(" failed");
 
 		if (cause.getCode() > 0)
@@ -199,7 +265,7 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 		if (responseDetails != null && !responseDetails.isBlank())
 			details.append(": ").append(responseDetails);
 
-		return new RepositoryRegistryLinkException(shellId, details.toString(), cause);
+		return details.toString();
 	}
 
 	private void rollbackAasUpdate(String shellId, AssetAdministrationShell previousShell, RuntimeException updateException) {
@@ -222,30 +288,23 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	private void deleteFromRegistry(String shellId) {
 		RegistryAndDiscoveryInterfaceApi registryApi = aasRepositoryRegistryLink.getRegistryApi();
-		
-		if (!shellExistsOnRegistry(shellId, registryApi)) {
-			logger.error("Unable to un-link the AAS descriptor '{}' from the Registry because it does not exist on the Registry.", shellId);
-			
-			return;
-		}
 
 		try {
 			registryApi.deleteAssetAdministrationShellDescriptorById(shellId);
 
 			logger.info("Shell '{}' has been automatically un-linked from the Registry.", shellId);
 		} catch (ApiException e) {
-			throw new RepositoryRegistryUnlinkException(shellId, e);
+			if (e.getCode() == 404) {
+				logger.info("Shell descriptor '{}' was already absent from the Registry.", shellId);
+				return;
+			}
+
+			throw createRegistryUnlinkException(shellId, e);
 		}
 	}
-	
-	private boolean shellExistsOnRegistry(String shellId, RegistryAndDiscoveryInterfaceApi registryApi) {
-		try {
-			registryApi.getAssetAdministrationShellDescriptorById(shellId);
-			
-			return true;
-		} catch (ApiException e) {
-			return false;
-		}
+
+	private Object getShellMutationLock(String shellId) {
+		return shellMutationLocks[Math.floorMod(Objects.hashCode(shellId), shellMutationLocks.length)];
 	}
 
 	@Override

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/main/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepository.java
@@ -79,7 +79,7 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	@Override
 	public void createAas(AssetAdministrationShell shell) throws CollidingIdentifierException {
-		AssetAdministrationShellDescriptor descriptor = new AasDescriptorFactory(aasRepositoryRegistryLink.getAasRepositoryBaseURLs(), attributeMapper).create(shell);
+		AssetAdministrationShellDescriptor descriptor = createDescriptor(shell);
 
 		decorated.createAas(shell);
 
@@ -96,7 +96,16 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	@Override
 	public void updateAas(String shellId, AssetAdministrationShell shell) {
+		AssetAdministrationShell previousShell = decorated.getAas(shellId);
+
 		decorated.updateAas(shellId, shell);
+
+		try {
+			updateDescriptor(shellId, shell);
+		} catch (RuntimeException e) {
+			rollbackAasUpdate(shellId, previousShell, e);
+			throw e;
+		}
 	}
 
 	@Override
@@ -128,7 +137,16 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 	@Override
 	public void setAssetInformation(String shellId, AssetInformation shellInfo) throws ElementDoesNotExistException {
+		AssetInformation previousAssetInformation = decorated.getAssetInformation(shellId);
+
 		decorated.setAssetInformation(shellId, shellInfo);
+
+		try {
+			updateDescriptor(shellId, decorated.getAas(shellId));
+		} catch (RuntimeException e) {
+			rollbackAssetInformationUpdate(shellId, previousAssetInformation, e);
+			throw e;
+		}
 	}
 
 	@Override
@@ -144,7 +162,61 @@ public class RegistryIntegrationAasRepository implements AasRepository {
 
 			logger.info("Shell '{}' has been automatically linked with the Registry", descriptor.getId());
 		} catch (ApiException e) {
-			throw new RepositoryRegistryLinkException(descriptor.getId(), e);
+			throw createRegistryLinkException(descriptor.getId(), "creation", e);
+		}
+	}
+
+	private void updateDescriptor(String shellId, AssetAdministrationShell shell) {
+		RegistryAndDiscoveryInterfaceApi registryApi = aasRepositoryRegistryLink.getRegistryApi();
+
+		try {
+			AssetAdministrationShellDescriptor existingDescriptor = registryApi.getAssetAdministrationShellDescriptorById(shellId);
+			AssetAdministrationShellDescriptor updatedDescriptor = createDescriptor(shell);
+			updatedDescriptor.setSubmodelDescriptors(existingDescriptor.getSubmodelDescriptors());
+
+			registryApi.putAssetAdministrationShellDescriptorById(shellId, updatedDescriptor);
+
+			logger.info("Shell descriptor '{}' has been automatically updated in the Registry", shellId);
+		} catch (ApiException e) {
+			throw createRegistryLinkException(shellId, "update", e);
+		}
+	}
+
+	private AssetAdministrationShellDescriptor createDescriptor(AssetAdministrationShell shell) {
+		return new AasDescriptorFactory(aasRepositoryRegistryLink.getAasRepositoryBaseURLs(), attributeMapper).create(shell);
+	}
+
+	private RepositoryRegistryLinkException createRegistryLinkException(String shellId, String operation, ApiException cause) {
+		StringBuilder details = new StringBuilder("Registry descriptor ").append(operation).append(" failed");
+
+		if (cause.getCode() > 0)
+			details.append(" with HTTP status ").append(cause.getCode());
+
+		String responseDetails = cause.getResponseBody();
+		if (responseDetails == null || responseDetails.isBlank())
+			responseDetails = cause.getMessage();
+
+		if (responseDetails != null && !responseDetails.isBlank())
+			details.append(": ").append(responseDetails);
+
+		return new RepositoryRegistryLinkException(shellId, details.toString(), cause);
+	}
+
+	private void rollbackAasUpdate(String shellId, AssetAdministrationShell previousShell, RuntimeException updateException) {
+		try {
+			decorated.updateAas(shellId, previousShell);
+		} catch (RuntimeException rollbackException) {
+			updateException.addSuppressed(rollbackException);
+			logger.error("Unable to restore AAS '{}' after Registry synchronization failed.", shellId, rollbackException);
+		}
+	}
+
+	private void rollbackAssetInformationUpdate(String shellId, AssetInformation previousAssetInformation, RuntimeException updateException) {
+		try {
+			decorated.setAssetInformation(shellId, previousAssetInformation);
+		} catch (RuntimeException rollbackException) {
+			updateException.addSuppressed(rollbackException);
+			logger.error("Unable to restore Asset Information for AAS '{}' after Registry synchronization failed.", shellId, rollbackException);
 		}
 	}
 

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/AasRepositoryRegistryLinkTestSuite.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/AasRepositoryRegistryLinkTestSuite.java
@@ -32,9 +32,11 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ParseException;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.ApiException;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.api.RegistryAndDiscoveryInterfaceApi;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetKind;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.GetAssetAdministrationShellDescriptorsResult;
 import org.eclipse.digitaltwin.basyx.aasregistry.main.client.mapper.DummyAasDescriptorFactory;
 import org.eclipse.digitaltwin.basyx.core.RepositoryUrlHelper;
@@ -93,6 +95,64 @@ public abstract class AasRepositoryRegistryLinkTestSuite {
 		assertDescriptionDeletionAtRegistry();
 	}
 
+	@Test
+	public void updateAasUpdatesDescriptor() throws FileNotFoundException, IOException, ApiException {
+		String updatedAas = getAas1JSONString()
+				.replace("\"ExampleMotor\"", "\"UpdatedMotor\"")
+				.replace("\"Instance\"", "\"Type\"");
+
+		try (CloseableHttpResponse creationResponse = createAasOnRepo(getAas1JSONString())) {
+			assertEquals(HttpStatus.CREATED.value(), creationResponse.getCode());
+		}
+
+		try {
+			try (CloseableHttpResponse updateResponse = updateAasOnRepo(updatedAas)) {
+				assertEquals(HttpStatus.NO_CONTENT.value(), updateResponse.getCode());
+			}
+
+			AssetAdministrationShellDescriptor descriptor = retrieveDescriptorFromRegistry();
+			assertEquals("UpdatedMotor", descriptor.getIdShort());
+			assertEquals(AssetKind.TYPE, descriptor.getAssetKind());
+		} finally {
+			resetRepository();
+		}
+	}
+
+	@Test
+	public void updateAssetInformationUpdatesDescriptor() throws FileNotFoundException, IOException, ApiException {
+		try (CloseableHttpResponse creationResponse = createAasOnRepo(getAas1JSONString())) {
+			assertEquals(HttpStatus.CREATED.value(), creationResponse.getCode());
+		}
+
+		try {
+			try (CloseableHttpResponse updateResponse = updateAssetInformationOnRepo("{\"assetKind\":\"Type\",\"globalAssetId\":\"globalAssetId\"}")) {
+				assertEquals(HttpStatus.NO_CONTENT.value(), updateResponse.getCode());
+			}
+
+			assertEquals(AssetKind.TYPE, retrieveDescriptorFromRegistry().getAssetKind());
+		} finally {
+			resetRepository();
+		}
+	}
+
+	@Test
+	public void preExistingDescriptorReturnsRegistryFailureDetailsAndRollsBackAas() throws IOException, ApiException, ParseException {
+		getAasRegistryApi().postAssetAdministrationShellDescriptor(DUMMY_DESCRIPTOR);
+
+		try {
+			try (CloseableHttpResponse creationResponse = createAasOnRepo(getAas1JSONString())) {
+				assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), creationResponse.getCode());
+				assertTrue(BaSyxHttpTestUtils.getResponseAsString(creationResponse).contains(Integer.toString(HttpStatus.CONFLICT.value())));
+			}
+
+			try (CloseableHttpResponse retrievalResponse = BaSyxHttpTestUtils.executeGetOnURL(getSpecificAasAccessURL(DUMMY_AAS_ID))) {
+				assertEquals(HttpStatus.NOT_FOUND.value(), retrievalResponse.getCode());
+			}
+		} finally {
+			getAasRegistryApi().deleteAssetAdministrationShellDescriptorById(DUMMY_AAS_ID);
+		}
+	}
+
 	private AssetAdministrationShellDescriptor retrieveDescriptorFromRegistry() throws ApiException {
 		RegistryAndDiscoveryInterfaceApi api = getAasRegistryApi();
 
@@ -125,8 +185,15 @@ public abstract class AasRepositoryRegistryLinkTestSuite {
 	}
 
 	private CloseableHttpResponse createAasOnRepo(String aasJsonContent) throws IOException {
-		String url = RepositoryUrlHelper.createRepositoryUrl(getFirstAasRepoBaseUrl(), AAS_REPOSITORY_PATH);
 		return BaSyxHttpTestUtils.executePostOnURL(RepositoryUrlHelper.createRepositoryUrl(getFirstAasRepoBaseUrl(), AAS_REPOSITORY_PATH), aasJsonContent);
+	}
+
+	private CloseableHttpResponse updateAasOnRepo(String aasJsonContent) throws IOException {
+		return BaSyxHttpTestUtils.executePutOnURL(getSpecificAasAccessURL(DUMMY_AAS_ID), aasJsonContent);
+	}
+
+	private CloseableHttpResponse updateAssetInformationOnRepo(String assetInformationJson) throws IOException {
+		return BaSyxHttpTestUtils.executePutOnURL(getSpecificAasAccessURL(DUMMY_AAS_ID) + "/asset-information", assetInformationJson);
 	}
 
 	private String getSpecificAasAccessURL(String aasId) {

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepositoryTest.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepositoryTest.java
@@ -26,25 +26,44 @@
 package org.eclipse.digitaltwin.basyx.aasrepository.feature.registry.integration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
+import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultKey;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.ApiException;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.api.RegistryAndDiscoveryInterfaceApi;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.Endpoint;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.ProtocolInformation;
 import org.eclipse.digitaltwin.basyx.aasregistry.client.model.SubmodelDescriptor;
 import org.eclipse.digitaltwin.basyx.aasregistry.main.client.mapper.AttributeMapper;
 import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
@@ -52,7 +71,9 @@ import org.eclipse.digitaltwin.basyx.aasrepository.backend.CrudAasRepositoryFact
 import org.eclipse.digitaltwin.basyx.aasservice.backend.InMemoryAasBackend;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
 import org.eclipse.digitaltwin.basyx.core.exceptions.RepositoryRegistryLinkException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.RepositoryRegistryUnlinkException;
 import org.eclipse.digitaltwin.basyx.core.filerepository.InMemoryFileRepository;
+import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -131,6 +152,24 @@ public class RegistryIntegrationAasRepositoryTest {
 	}
 
 	@Test
+	public void updateAasPreservesRegistryEndpointMetadata() throws ApiException {
+		decorated.createAas(createShell("old-id-short", AssetKind.INSTANCE));
+		AssetAdministrationShellDescriptor existingDescriptor = createExistingDescriptor();
+		ProtocolInformation protocolInformation = new ProtocolInformation()
+				.href("https://registry.example/shell")
+				.endpointProtocol("https")
+				.endpointProtocolVersion(List.of("1.1"))
+				.subprotocol("custom-subprotocol");
+		Endpoint endpoint = new Endpoint()._interface("AAS-3.0").protocolInformation(protocolInformation);
+		existingDescriptor.setEndpoints(List.of(endpoint));
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(existingDescriptor);
+
+		repository.updateAas(AAS_ID, createShell("new-id-short", AssetKind.INSTANCE));
+
+		assertEquals(List.of(endpoint), captureUpdatedDescriptor().getEndpoints());
+	}
+
+	@Test
 	public void failedDescriptorUpdateRestoresPreviousAas() throws ApiException {
 		AssetAdministrationShell initialShell = createShell("old-id-short", AssetKind.INSTANCE);
 		decorated.createAas(initialShell);
@@ -153,6 +192,234 @@ public class RegistryIntegrationAasRepositoryTest {
 		assertThrows(RepositoryRegistryLinkException.class, () -> repository.setAssetInformation(AAS_ID, createAssetInformation(AssetKind.TYPE)));
 
 		assertEquals(AssetKind.INSTANCE, decorated.getAssetInformation(AAS_ID).getAssetKind());
+	}
+
+	@Test
+	public void committedDescriptorUpdateWithLostResponseDoesNotRollBackAas() throws ApiException {
+		decorated.createAas(createShell("old-id-short", AssetKind.INSTANCE));
+		AtomicReference<AssetAdministrationShellDescriptor> registryDescriptor = new AtomicReference<>(createExistingDescriptor());
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenAnswer(invocation -> registryDescriptor.get());
+		doAnswer(invocation -> {
+			registryDescriptor.set(invocation.getArgument(1));
+			throw new ApiException(503, "response lost");
+		}).when(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
+
+		repository.updateAas(AAS_ID, createShell("new-id-short", AssetKind.TYPE));
+
+		assertEquals("new-id-short", decorated.getAas(AAS_ID).getIdShort());
+		assertEquals("new-id-short", registryDescriptor.get().getIdShort());
+	}
+
+	@Test
+	public void concurrentUpdatesThroughSameIntegrationInstanceRemainOrdered() throws Exception {
+		decorated.createAas(createShell("initial", AssetKind.INSTANCE));
+		AtomicReference<AssetAdministrationShellDescriptor> registryDescriptor = new AtomicReference<>(createExistingDescriptor());
+		AtomicInteger putCount = new AtomicInteger();
+		CountDownLatch firstPutStarted = new CountDownLatch(1);
+		CountDownLatch releaseFirstPut = new CountDownLatch(1);
+		CountDownLatch secondUpdateInvoked = new CountDownLatch(1);
+		CountDownLatch secondPutStarted = new CountDownLatch(1);
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenAnswer(invocation -> registryDescriptor.get());
+		doAnswer(invocation -> {
+			AssetAdministrationShellDescriptor descriptor = invocation.getArgument(1);
+			if (putCount.incrementAndGet() == 1) {
+				firstPutStarted.countDown();
+				releaseFirstPut.await(2, TimeUnit.SECONDS);
+			} else {
+				secondPutStarted.countDown();
+			}
+			registryDescriptor.set(descriptor);
+			return null;
+		}).when(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<?> firstUpdate = executor.submit(() -> repository.updateAas(AAS_ID, createShell("first", AssetKind.INSTANCE)));
+			assertTrue(firstPutStarted.await(1, TimeUnit.SECONDS));
+			Future<?> secondUpdate = executor.submit(() -> {
+				secondUpdateInvoked.countDown();
+				repository.updateAas(AAS_ID, createShell("second", AssetKind.TYPE));
+			});
+			assertTrue(secondUpdateInvoked.await(1, TimeUnit.SECONDS));
+			assertFalse(secondPutStarted.await(200, TimeUnit.MILLISECONDS));
+			releaseFirstPut.countDown();
+
+			firstUpdate.get(2, TimeUnit.SECONDS);
+			secondUpdate.get(2, TimeUnit.SECONDS);
+
+			assertEquals("second", decorated.getAas(AAS_ID).getIdShort());
+			assertEquals("second", registryDescriptor.get().getIdShort());
+		} finally {
+			releaseFirstPut.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	public void failedUpdateRollbackDoesNotOverwriteLaterUpdateThroughSameIntegrationInstance() throws Exception {
+		decorated.createAas(createShell("initial", AssetKind.INSTANCE));
+		AtomicReference<AssetAdministrationShellDescriptor> registryDescriptor = new AtomicReference<>(createExistingDescriptor());
+		AtomicInteger putCount = new AtomicInteger();
+		CountDownLatch firstPutStarted = new CountDownLatch(1);
+		CountDownLatch releaseFirstPut = new CountDownLatch(1);
+		CountDownLatch secondUpdateInvoked = new CountDownLatch(1);
+		CountDownLatch secondPutStarted = new CountDownLatch(1);
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenAnswer(invocation -> registryDescriptor.get());
+		doAnswer(invocation -> {
+			AssetAdministrationShellDescriptor descriptor = invocation.getArgument(1);
+			if (putCount.incrementAndGet() == 1) {
+				firstPutStarted.countDown();
+				releaseFirstPut.await(2, TimeUnit.SECONDS);
+				throw new ApiException(503, "registry unavailable");
+			}
+
+			secondPutStarted.countDown();
+			registryDescriptor.set(descriptor);
+			return null;
+		}).when(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<?> failedUpdate = executor.submit(() -> repository.updateAas(AAS_ID, createShell("failed", AssetKind.INSTANCE)));
+			assertTrue(firstPutStarted.await(1, TimeUnit.SECONDS));
+			Future<?> successfulUpdate = executor.submit(() -> {
+				secondUpdateInvoked.countDown();
+				repository.updateAas(AAS_ID, createShell("successful", AssetKind.TYPE));
+			});
+			assertTrue(secondUpdateInvoked.await(1, TimeUnit.SECONDS));
+			assertFalse(secondPutStarted.await(200, TimeUnit.MILLISECONDS));
+			releaseFirstPut.countDown();
+
+			ExecutionException exception = assertThrows(ExecutionException.class, () -> failedUpdate.get(2, TimeUnit.SECONDS));
+			assertTrue(exception.getCause() instanceof RepositoryRegistryLinkException);
+			successfulUpdate.get(2, TimeUnit.SECONDS);
+
+			assertEquals("successful", decorated.getAas(AAS_ID).getIdShort());
+			assertEquals("successful", registryDescriptor.get().getIdShort());
+		} finally {
+			releaseFirstPut.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	public void failedUpdateRollbackDoesNotOverwriteConcurrentSubmodelReferenceChange() throws Exception {
+		decorated.createAas(createShell("initial", AssetKind.INSTANCE));
+		CountDownLatch putStarted = new CountDownLatch(1);
+		CountDownLatch releasePut = new CountDownLatch(1);
+		CountDownLatch addReferenceInvoked = new CountDownLatch(1);
+		CountDownLatch submodelReferenceAdded = new CountDownLatch(1);
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(createExistingDescriptor());
+		doAnswer(invocation -> {
+			putStarted.countDown();
+			releasePut.await(2, TimeUnit.SECONDS);
+			throw new ApiException(503, "registry unavailable");
+		}).when(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<?> failedUpdate = executor.submit(() -> repository.updateAas(AAS_ID, createShell("failed", AssetKind.TYPE)));
+			assertTrue(putStarted.await(1, TimeUnit.SECONDS));
+			Future<?> addReference = executor.submit(() -> {
+				addReferenceInvoked.countDown();
+				repository.addSubmodelReference(AAS_ID, createSubmodelReference("submodel-id"));
+				submodelReferenceAdded.countDown();
+			});
+			assertTrue(addReferenceInvoked.await(1, TimeUnit.SECONDS));
+			assertFalse(submodelReferenceAdded.await(200, TimeUnit.MILLISECONDS));
+			releasePut.countDown();
+
+			ExecutionException exception = assertThrows(ExecutionException.class, () -> failedUpdate.get(2, TimeUnit.SECONDS));
+			assertTrue(exception.getCause() instanceof RepositoryRegistryLinkException);
+			addReference.get(2, TimeUnit.SECONDS);
+
+			assertEquals(List.of(createSubmodelReference("submodel-id")), decorated.getSubmodelReferences(AAS_ID, PaginationInfo.NO_LIMIT).getResult());
+		} finally {
+			releasePut.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	public void concurrentCreateAndDeleteThroughSameIntegrationInstanceRemainOrdered() throws Exception {
+		AtomicBoolean descriptorExists = new AtomicBoolean();
+		CountDownLatch registrationStarted = new CountDownLatch(1);
+		CountDownLatch releaseRegistration = new CountDownLatch(1);
+		CountDownLatch deleteInvoked = new CountDownLatch(1);
+		CountDownLatch deletionAttempted = new CountDownLatch(1);
+		doAnswer(invocation -> {
+			registrationStarted.countDown();
+			releaseRegistration.await(2, TimeUnit.SECONDS);
+			descriptorExists.set(true);
+			return null;
+		}).when(registryApi).postAssetAdministrationShellDescriptor(any());
+		doAnswer(invocation -> {
+			deletionAttempted.countDown();
+			if (!descriptorExists.getAndSet(false))
+				throw new ApiException(404, "descriptor not found");
+			return null;
+		}).when(registryApi).deleteAssetAdministrationShellDescriptorById(AAS_ID);
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<?> create = executor.submit(() -> repository.createAas(createShell("id-short", AssetKind.INSTANCE)));
+			assertTrue(registrationStarted.await(1, TimeUnit.SECONDS));
+			Future<?> delete = executor.submit(() -> {
+				deleteInvoked.countDown();
+				repository.deleteAas(AAS_ID);
+			});
+			assertTrue(deleteInvoked.await(1, TimeUnit.SECONDS));
+			assertFalse(deletionAttempted.await(200, TimeUnit.MILLISECONDS));
+			releaseRegistration.countDown();
+
+			create.get(2, TimeUnit.SECONDS);
+			delete.get(2, TimeUnit.SECONDS);
+
+			assertThrows(ElementDoesNotExistException.class, () -> decorated.getAas(AAS_ID));
+			assertFalse(descriptorExists.get());
+		} finally {
+			releaseRegistration.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	public void missingRegistryDescriptorStillDeletesAasWithoutReadingIt() throws ApiException {
+		decorated.createAas(createShell("id-short", AssetKind.INSTANCE));
+		doThrow(new ApiException(404, "descriptor not found")).when(registryApi).deleteAssetAdministrationShellDescriptorById(AAS_ID);
+
+		repository.deleteAas(AAS_ID);
+
+		assertThrows(ElementDoesNotExistException.class, () -> decorated.getAas(AAS_ID));
+		verify(registryApi).deleteAssetAdministrationShellDescriptorById(AAS_ID);
+		verify(registryApi, never()).getAssetAdministrationShellDescriptorById(AAS_ID);
+	}
+
+	@Test
+	public void registryDeleteFailureKeepsAasAndReportsDetails() throws ApiException {
+		decorated.createAas(createShell("id-short", AssetKind.INSTANCE));
+		doThrow(new ApiException(503, "registry request failed", null, "registry unavailable")).when(registryApi).deleteAssetAdministrationShellDescriptorById(AAS_ID);
+
+		RepositoryRegistryUnlinkException exception = assertThrows(RepositoryRegistryUnlinkException.class, () -> repository.deleteAas(AAS_ID));
+
+		assertTrue(exception.getMessage().contains("503"));
+		assertTrue(exception.getMessage().contains("registry unavailable"));
+		assertEquals("id-short", decorated.getAas(AAS_ID).getIdShort());
+		verify(registryApi, never()).getAssetAdministrationShellDescriptorById(AAS_ID);
+	}
+
+	@Test
+	public void registryReadPermissionFailureRollsBackAasAndReportsDetails() throws ApiException {
+		decorated.createAas(createShell("old-id-short", AssetKind.INSTANCE));
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenThrow(new ApiException(403, "forbidden", null, "read permission required"));
+
+		RepositoryRegistryLinkException exception = assertThrows(RepositoryRegistryLinkException.class,
+				() -> repository.updateAas(AAS_ID, createShell("new-id-short", AssetKind.TYPE)));
+
+		assertTrue(exception.getMessage().contains("403"));
+		assertTrue(exception.getMessage().contains("read permission required"));
+		assertEquals("old-id-short", decorated.getAas(AAS_ID).getIdShort());
+		verify(registryApi, never()).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
 	}
 
 	@Test
@@ -199,6 +466,13 @@ public class RegistryIntegrationAasRepositoryTest {
 		return new DefaultAssetInformation.Builder()
 				.assetKind(assetKind)
 				.globalAssetId("global-asset-id")
+				.build();
+	}
+
+	private Reference createSubmodelReference(String submodelId) {
+		return new DefaultReference.Builder()
+				.type(ReferenceTypes.MODEL_REFERENCE)
+				.keys(new DefaultKey.Builder().type(KeyTypes.SUBMODEL).value(submodelId).build())
 				.build();
 	}
 }

--- a/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepositoryTest.java
+++ b/basyx.aasrepository/basyx.aasrepository-feature-registry-integration/src/test/java/org/eclipse/digitaltwin/basyx/aasrepository/feature/registry/integration/RegistryIntegrationAasRepositoryTest.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (C) 2026 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+package org.eclipse.digitaltwin.basyx.aasrepository.feature.registry.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetInformation;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.ApiException;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.api.RegistryAndDiscoveryInterfaceApi;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.client.model.SubmodelDescriptor;
+import org.eclipse.digitaltwin.basyx.aasregistry.main.client.mapper.AttributeMapper;
+import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
+import org.eclipse.digitaltwin.basyx.aasrepository.backend.CrudAasRepositoryFactory;
+import org.eclipse.digitaltwin.basyx.aasservice.backend.InMemoryAasBackend;
+import org.eclipse.digitaltwin.basyx.core.exceptions.ElementDoesNotExistException;
+import org.eclipse.digitaltwin.basyx.core.exceptions.RepositoryRegistryLinkException;
+import org.eclipse.digitaltwin.basyx.core.filerepository.InMemoryFileRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for registry synchronization in {@link RegistryIntegrationAasRepository}.
+ */
+public class RegistryIntegrationAasRepositoryTest {
+	private static final String AAS_ID = "aas-id";
+	private static final String REPOSITORY_URL = "http://localhost:8081";
+
+	private AasRepository decorated;
+	private RegistryAndDiscoveryInterfaceApi registryApi;
+	private RegistryIntegrationAasRepository repository;
+
+	@Before
+	public void setUp() {
+		decorated = CrudAasRepositoryFactory.builder().backend(new InMemoryAasBackend()).fileRepository(new InMemoryFileRepository()).create();
+		registryApi = mock(RegistryAndDiscoveryInterfaceApi.class);
+
+		AasRepositoryRegistryLink registryLink = mock(AasRepositoryRegistryLink.class);
+		when(registryLink.getRegistryApi()).thenReturn(registryApi);
+		when(registryLink.getAasRepositoryBaseURLs()).thenReturn(List.of(REPOSITORY_URL));
+
+		repository = new RegistryIntegrationAasRepository(decorated, registryLink, new AttributeMapper(new ObjectMapper()));
+	}
+
+	@Test
+	public void updateAasAddsIdShortToDescriptor() throws ApiException {
+		AssetAdministrationShell initialShell = createShell(null, AssetKind.INSTANCE);
+		decorated.createAas(initialShell);
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(createExistingDescriptor());
+
+		repository.updateAas(AAS_ID, createShell("added-id-short", AssetKind.INSTANCE));
+
+		AssetAdministrationShellDescriptor updatedDescriptor = captureUpdatedDescriptor();
+		assertEquals("added-id-short", updatedDescriptor.getIdShort());
+	}
+
+	@Test
+	public void updateAasUpdatesAssetKindInDescriptor() throws ApiException {
+		decorated.createAas(createShell("id-short", AssetKind.INSTANCE));
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(createExistingDescriptor());
+
+		repository.updateAas(AAS_ID, createShell("id-short", AssetKind.TYPE));
+
+		AssetAdministrationShellDescriptor updatedDescriptor = captureUpdatedDescriptor();
+		assertEquals(org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetKind.TYPE, updatedDescriptor.getAssetKind());
+	}
+
+	@Test
+	public void setAssetInformationUpdatesAssetKindInDescriptor() throws ApiException {
+		decorated.createAas(createShell("id-short", AssetKind.INSTANCE));
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(createExistingDescriptor());
+
+		repository.setAssetInformation(AAS_ID, createAssetInformation(AssetKind.TYPE));
+
+		AssetAdministrationShellDescriptor updatedDescriptor = captureUpdatedDescriptor();
+		assertEquals(org.eclipse.digitaltwin.basyx.aasregistry.client.model.AssetKind.TYPE, updatedDescriptor.getAssetKind());
+	}
+
+	@Test
+	public void updateAasPreservesSubmodelDescriptors() throws ApiException {
+		decorated.createAas(createShell("old-id-short", AssetKind.INSTANCE));
+		AssetAdministrationShellDescriptor existingDescriptor = createExistingDescriptor();
+		SubmodelDescriptor submodelDescriptor = new SubmodelDescriptor();
+		submodelDescriptor.setId("submodel-id");
+		existingDescriptor.setSubmodelDescriptors(List.of(submodelDescriptor));
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(existingDescriptor);
+
+		repository.updateAas(AAS_ID, createShell("new-id-short", AssetKind.INSTANCE));
+
+		assertEquals(List.of(submodelDescriptor), captureUpdatedDescriptor().getSubmodelDescriptors());
+	}
+
+	@Test
+	public void failedDescriptorUpdateRestoresPreviousAas() throws ApiException {
+		AssetAdministrationShell initialShell = createShell("old-id-short", AssetKind.INSTANCE);
+		decorated.createAas(initialShell);
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(createExistingDescriptor());
+		doThrow(new ApiException(503, "registry unavailable")).when(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
+
+		assertThrows(RepositoryRegistryLinkException.class, () -> repository.updateAas(AAS_ID, createShell("new-id-short", AssetKind.TYPE)));
+
+		AssetAdministrationShell restoredShell = decorated.getAas(AAS_ID);
+		assertEquals("old-id-short", restoredShell.getIdShort());
+		assertEquals(AssetKind.INSTANCE, restoredShell.getAssetInformation().getAssetKind());
+	}
+
+	@Test
+	public void failedAssetInformationUpdateRestoresPreviousAssetInformation() throws ApiException {
+		decorated.createAas(createShell("id-short", AssetKind.INSTANCE));
+		when(registryApi.getAssetAdministrationShellDescriptorById(AAS_ID)).thenReturn(createExistingDescriptor());
+		doThrow(new ApiException(503, "registry unavailable")).when(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), any());
+
+		assertThrows(RepositoryRegistryLinkException.class, () -> repository.setAssetInformation(AAS_ID, createAssetInformation(AssetKind.TYPE)));
+
+		assertEquals(AssetKind.INSTANCE, decorated.getAssetInformation(AAS_ID).getAssetKind());
+	}
+
+	@Test
+	public void createAasReportsRegistryConflictDetailsAndRollsBackRepository() throws ApiException {
+		assertCreateFailureContainsRegistryDetails(409, "descriptor already exists");
+	}
+
+	@Test
+	public void createAasReportsRegistryServiceFailureDetailsAndRollsBackRepository() throws ApiException {
+		assertCreateFailureContainsRegistryDetails(503, "registry unavailable");
+	}
+
+	private void assertCreateFailureContainsRegistryDetails(int status, String detail) throws ApiException {
+		doThrow(new ApiException(status, "registry request failed", null, detail)).when(registryApi).postAssetAdministrationShellDescriptor(any());
+
+		RepositoryRegistryLinkException exception = assertThrows(RepositoryRegistryLinkException.class, () -> repository.createAas(createShell("id-short", AssetKind.INSTANCE)));
+
+		assertTrue(exception.getMessage().contains(Integer.toString(status)));
+		assertTrue(exception.getMessage().contains(detail));
+		assertThrows(ElementDoesNotExistException.class, () -> decorated.getAas(AAS_ID));
+	}
+
+	private AssetAdministrationShellDescriptor captureUpdatedDescriptor() throws ApiException {
+		ArgumentCaptor<AssetAdministrationShellDescriptor> descriptorCaptor = ArgumentCaptor.forClass(AssetAdministrationShellDescriptor.class);
+		verify(registryApi).putAssetAdministrationShellDescriptorById(eq(AAS_ID), descriptorCaptor.capture());
+		return descriptorCaptor.getValue();
+	}
+
+	private AssetAdministrationShellDescriptor createExistingDescriptor() {
+		AssetAdministrationShellDescriptor descriptor = new AssetAdministrationShellDescriptor();
+		descriptor.setId(AAS_ID);
+		return descriptor;
+	}
+
+	private AssetAdministrationShell createShell(String idShort, AssetKind assetKind) {
+		return new DefaultAssetAdministrationShell.Builder()
+				.id(AAS_ID)
+				.idShort(idShort)
+				.assetInformation(createAssetInformation(assetKind))
+				.build();
+	}
+
+	private AssetInformation createAssetInformation(AssetKind assetKind) {
+		return new DefaultAssetInformation.Builder()
+				.assetKind(assetKind)
+				.globalAssetId("global-asset-id")
+				.build();
+	}
+}

--- a/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryLinkException.java
+++ b/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryLinkException.java
@@ -39,8 +39,16 @@ public class RepositoryRegistryLinkException extends RuntimeException {
 		super(getMessage(id), th);
 	}
 
+	public RepositoryRegistryLinkException(String id, String details, Throwable th) {
+		super(getMessage(id, details), th);
+	}
+
 	private static String getMessage(String id) {
 		return "Unable to link the element with id '" + id + "' with the Registry.";
+	}
+
+	private static String getMessage(String id, String details) {
+		return getMessage(id) + " " + details;
 	}
 
 }

--- a/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryUnlinkException.java
+++ b/basyx.common/basyx.core/src/main/java/org/eclipse/digitaltwin/basyx/core/exceptions/RepositoryRegistryUnlinkException.java
@@ -38,6 +38,10 @@ public class RepositoryRegistryUnlinkException extends RuntimeException {
 		super(getMessage(id), th);
 	}
 
+	public RepositoryRegistryUnlinkException(String id, String details, Throwable th) {
+		super(getMessage(id) + " " + details, th);
+	}
+
 	private static String getMessage(String id) {
 		return "Unable to unlink the element with id '" + id + "' from the Registry.";
 	}


### PR DESCRIPTION
# Pull Request Template

## Description of Changes

The registry integration created and deleted AAS descriptors, but it did not keep them in sync when an AAS or its Asset Information was updated. This change updates the descriptor after both operations and retains existing Submodel Descriptors and Registry-managed endpoint metadata.

Mutations for the same AAS are serialized within one repository instance so that concurrent updates, rollbacks, deletes, and Submodel reference changes cannot overtake each other. If a Registry PUT returns an ambiguous error, the integration reads the descriptor back and only rolls the repository back when the requested AAS-derived state is not present.

Registry deletion now calls DELETE directly, treats only 404 as already absent, and keeps the local AAS for every other Registry failure. Link and unlink errors include the operation, HTTP status, and response body.

The feature documentation now lists the required Registry permissions: CREATE for creation, READ and UPDATE for synchronization, and DELETE for deletion.

## Related Issue

Closes #998
Closes #1016
Closes #927

## BaSyx Configuration for Testing

No special configuration is required for the unit tests. They use the in-memory backend and a mocked Registry client.

The service-backed integration tests use the existing regintegration, multiurl, and authregistry profiles with their corresponding Registry and Keycloak services.

## AAS Files Used for Testing

The existing AasSimple_1.json fixture is used by the HTTP integration tests. The unit tests create their AAS instances programmatically.

## Additional Information

The fix was implemented test-first. Regression tests cover descriptor updates, rollback behavior, concurrent same-instance mutations, ambiguous PUT responses, endpoint and Submodel Descriptor preservation, detailed create/delete errors, and Registry permission failures.

The Registry API currently has no conditional PUT or partial Shell Descriptor update. Direct descriptor changes by another Registry client therefore must not run concurrently with an AAS update if both changes need to be retained.

Validation performed:

- mvn -pl basyx.common/basyx.core test
- mvn -pl basyx.aasrepository/basyx.aasrepository-feature-registry-integration -Dtest=RegistryIntegrationAasRepositoryTest,AasRepositoryRegistryLinkDescriptorGenerationTest test
- mvn -pl basyx.aasrepository/basyx.aasrepository-feature-registry-integration -am -DskipTests package

The full service-backed module suite was also attempted locally. Its external-service cases could not run because the Registry and Keycloak test services were not available.

---

Please ensure that you have tested your changes thoroughly before submitting the pull request.