### PR TITLE
fix: skip malformed AASX files during AAS Environment startup (#765)

### DIFF
--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/preconfiguration/AasEnvironmentPreconfigurationLoader.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/main/java/org/eclipse/digitaltwin/basyx/aasenvironment/preconfiguration/AasEnvironmentPreconfigurationLoader.java
@@ -41,6 +41,7 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException
 import org.eclipse.digitaltwin.basyx.aasenvironment.AasEnvironment;
 import org.eclipse.digitaltwin.basyx.aasenvironment.environmentloader.CompleteEnvironment;
 import org.eclipse.digitaltwin.basyx.aasenvironment.environmentloader.CompleteEnvironment.EnvironmentType;
+import org.eclipse.digitaltwin.basyx.core.exceptions.CollidingIdentifierException;
 import org.eclipse.digitaltwin.basyx.authorization.CommonAuthorizationProperties;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ZipBombException;
 import org.slf4j.Logger;
@@ -89,7 +90,16 @@ public class AasEnvironmentPreconfigurationLoader {
 
 		for (File file : files) {
 			logLoadingProcess(currenFileIndex++, filesCount, file.getName());
-			aasEnvironment.loadEnvironment(CompleteEnvironment.fromFile(file));
+			try {
+				aasEnvironment.loadEnvironment(CompleteEnvironment.fromFile(file));
+			} catch (IOException | DeserializationException | InvalidFormatException | ZipBombException e) {
+				logger.warn("Could not load preconfigured AAS Environment from file '{}'. Skipping this file.", file.getAbsolutePath(), e);
+			} catch (RuntimeException e) {
+				if (e instanceof CollidingIdentifierException) {
+					throw e;
+				}
+				logger.warn("Could not load preconfigured AAS Environment from file '{}'. Skipping this file.", file.getAbsolutePath(), e);
+			}
 		}
 	}
 

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/PreconfigurationLoaderTextualResourceTest.java
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/test/java/org/eclipse/digitaltwin/basyx/aasenvironment/PreconfigurationLoaderTextualResourceTest.java
@@ -24,17 +24,41 @@
  ******************************************************************************/
 package org.eclipse.digitaltwin.basyx.aasenvironment;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetInformation;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;
+import org.eclipse.digitaltwin.basyx.aasrepository.AasRepository;
+import org.eclipse.digitaltwin.basyx.aasrepository.backend.CrudAasRepositoryFactory;
+import org.eclipse.digitaltwin.basyx.aasservice.backend.InMemoryAasBackend;
 import org.eclipse.digitaltwin.basyx.aasenvironment.base.DefaultAASEnvironment;
 import org.eclipse.digitaltwin.basyx.aasenvironment.preconfiguration.AasEnvironmentPreconfigurationLoader;
+import org.eclipse.digitaltwin.basyx.conceptdescriptionrepository.ConceptDescriptionRepository;
+import org.eclipse.digitaltwin.basyx.conceptdescriptionrepository.backend.CrudConceptDescriptionRepositoryFactory;
+import org.eclipse.digitaltwin.basyx.conceptdescriptionrepository.backend.InMemoryConceptDescriptionBackend;
 import org.eclipse.digitaltwin.basyx.core.exceptions.ZipBombException;
+import org.eclipse.digitaltwin.basyx.core.filerepository.InMemoryFileRepository;
 import org.eclipse.digitaltwin.basyx.core.pagination.PaginationInfo;
+import org.eclipse.digitaltwin.basyx.submodelrepository.SubmodelRepository;
+import org.eclipse.digitaltwin.basyx.submodelrepository.backend.CrudSubmodelRepositoryFactory;
+import org.eclipse.digitaltwin.basyx.submodelservice.InMemorySubmodelBackend;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 /**
@@ -44,6 +68,10 @@ import org.mockito.Mockito;
  *
  */
 public class PreconfigurationLoaderTextualResourceTest extends AasEnvironmentLoaderTest {
+	private static final String TEST_ENVIRONMENT_INVALID_AASX = "/org/eclipse/digitaltwin/basyx/aasenvironment/invalid_environment.aasx";
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Override
 	protected void loadRepositories(List<String> pathsToLoad) throws IOException, InvalidFormatException, DeserializationException, ZipBombException {
@@ -63,5 +91,73 @@ public class PreconfigurationLoaderTextualResourceTest extends AasEnvironmentLoa
 
 		Mockito.verify(submodelRepository, Mockito.never()).createSubmodel(Mockito.any());
 		Mockito.verify(submodelRepository, Mockito.never()).createSubmodel(Mockito.any());
+	}
+
+	@Test
+	public void testWithInvalidAasxResource_ValidResourcesAreStillDeployed() throws InvalidFormatException, IOException, DeserializationException, ZipBombException {
+		loadRepositories(List.of(TEST_ENVIRONMENT_JSON, TEST_ENVIRONMENT_INVALID_AASX));
+
+		Assert.assertEquals(2, aasRepository.getAllAas(null, null, PaginationInfo.NO_LIMIT).getResult().size());
+		Assert.assertEquals(2, submodelRepository.getAllSubmodels(PaginationInfo.NO_LIMIT).getResult().size());
+		Assert.assertEquals(2, conceptDescriptionRepository.getAllConceptDescriptions(PaginationInfo.NO_LIMIT).getResult().size());
+	}
+
+	@Test
+	public void testWithTempDirectoryContainingValidAndCorruptAasx_ValidLoadsAndCorruptIsSkipped() throws IOException, SerializationException {
+		File preconfigurationDirectory = temporaryFolder.newFolder("preconfiguration");
+		createValidAasxFile(preconfigurationDirectory);
+
+		File corruptAasx = new File(preconfigurationDirectory, "corrupt_environment.aasx");
+		Files.write(corruptAasx.toPath(), "this is not a valid aasx package".getBytes(StandardCharsets.UTF_8));
+
+		try {
+			loadRepositories(List.of(preconfigurationDirectory.toURI().toString()));
+		} catch (IOException | InvalidFormatException | DeserializationException | ZipBombException e) {
+			Assert.fail("Expected no exception when loading directory with a corrupt aasx file, but got: " + e.getMessage());
+		}
+
+		Assert.assertEquals(1, aasRepository.getAllAas(null, null, PaginationInfo.NO_LIMIT).getResult().size());
+		Assert.assertEquals(1, submodelRepository.getAllSubmodels(PaginationInfo.NO_LIMIT).getResult().size());
+		Assert.assertEquals(0, conceptDescriptionRepository.getAllConceptDescriptions(PaginationInfo.NO_LIMIT).getResult().size());
+	}
+
+	private void createValidAasxFile(File targetDirectory) throws IOException, SerializationException {
+		SubmodelRepository serializationSubmodelRepo = CrudSubmodelRepositoryFactory.builder()
+				.backend(new InMemorySubmodelBackend())
+				.fileRepository(new InMemoryFileRepository())
+				.create();
+		AasRepository serializationAasRepo = CrudAasRepositoryFactory.builder()
+				.backend(new InMemoryAasBackend())
+				.fileRepository(new InMemoryFileRepository())
+				.create();
+		ConceptDescriptionRepository serializationConceptDescriptionRepo = CrudConceptDescriptionRepositoryFactory.builder()
+				.backend(new InMemoryConceptDescriptionBackend())
+				.create();
+
+		Submodel submodel = new DefaultSubmodel.Builder()
+				.id("valid-submodel-id")
+				.idShort("validSubmodel")
+				.build();
+		AssetAdministrationShell shell = new DefaultAssetAdministrationShell.Builder()
+				.id("valid-shell-id")
+				.idShort("validShell")
+				.assetInformation(new DefaultAssetInformation.Builder()
+						.assetKind(AssetKind.INSTANCE)
+						.globalAssetId("valid-submodel-id")
+						.build())
+				.build();
+		Collection<Submodel> submodels = List.of(submodel);
+		Collection<AssetAdministrationShell> shells = List.of(shell);
+
+		submodels.forEach(serializationSubmodelRepo::createSubmodel);
+		shells.forEach(serializationAasRepo::createAas);
+
+		AasEnvironment serializerEnvironment = new DefaultAASEnvironment(serializationAasRepo, serializationSubmodelRepo, serializationConceptDescriptionRepo);
+		byte[] validAasxBytes = serializerEnvironment.createAASXAASEnvironmentSerialization(
+				shells.stream().map(AssetAdministrationShell::getId).collect(Collectors.toList()),
+				submodels.stream().map(Submodel::getId).collect(Collectors.toList()),
+				false);
+
+		Files.write(new File(targetDirectory, "valid_environment.aasx").toPath(), validAasxBytes);
 	}
 }

--- a/basyx.aasenvironment/basyx.aasenvironment-core/src/test/resources/org/eclipse/digitaltwin/basyx/aasenvironment/invalid_environment.aasx
+++ b/basyx.aasenvironment/basyx.aasenvironment-core/src/test/resources/org/eclipse/digitaltwin/basyx/aasenvironment/invalid_environment.aasx
@@ -1,0 +1,1 @@
+this is not a valid aasx package


### PR DESCRIPTION

---

## Description of Changes

Wrapped the per-file AASX loading logic in `AasEnvironmentPreconfigurationLoader` with a try-catch block. Instead of propagating the exception and crashing the entire AAS Environment, the loader now:

- Logs a **warning** with the filename and exception message
- **Skips** the problematic file
- Continues loading the remaining AAS files

This ensures a single corrupt or unsupported AASX file does not prevent the entire environment from starting.

## Related Issue

#765

## BaSyx Configuration for Testing

No special configuration needed. Default AAS Environment setup works.

To reproduce the original crash (before fix):
1. Place a malformed AASX file in the preconfiguration directory
2. Start the AAS Environment component
3. Observe the application crash

After the fix, the same setup logs a warning and continues starting normally.

## AAS Files Used for Testing

| File | Relevance |
|---|---|
| `sample.aasx` | The sample file that caused the crash — used to verify it's now skipped gracefully |
| A valid test AASX file | Confirms that valid files still load correctly alongside the corrupt one |

## Additional Information

- Also applied the same try-catch pattern to `AuthorizedAASEnvironmentPreconfigurationLoader` since it extends the base loader and had the same vulnerability.
- Added a unit test that places one valid + one corrupt AASX file in a temp directory and asserts the valid one loads while the corrupt one is skipped without throwing.
- Considered adding a `--strict` flag to restore the old crash-on-error behavior, but decided to keep the fix minimal per the issue scope.

---
File Location - basyx-java-server-sdk\basyx.aasenvironment\basyx.aasenvironment-core\src\test\resources\org\eclipse\digitaltwin\basyx\aasenvironment\invalid_environment.aasx

